### PR TITLE
Add validator overview & details

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Things that might be worth adding at some time
 
 * Validator Overview & Details\
   The current validator set is actually already maintained in memory. So it should be easy to add pages for basic validator related stuff.
-  * [ ] Page: Validators List (`/validators`)
+  * [x] Page: Validators List (`/validators`)
   * [ ] Page: Validator Details (`/validator/{validator_index}`)
     * [ ] Rough overview with status (activated, slashed, ...) & current balance
     * [ ] Recent Blocks (from db) 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Things that might be worth adding at some time
 * Validator Overview & Details\
   The current validator set is actually already maintained in memory. So it should be easy to add pages for basic validator related stuff.
   * [x] Page: Validators List (`/validators`)
-  * [ ] Page: Validator Details (`/validator/{validator_index}`)
-    * [ ] Rough overview with status (activated, slashed, ...) & current balance
-    * [ ] Recent Blocks (from db) 
+  * [x] Page: Validator Details (`/validator/{validator_index}`)
+    * [x] Rough overview with status (activated, slashed, ...) & current balance
+    * [x] Recent Blocks (from db) 
     * [ ] Recent Attestations (from cache) 
 * Track Sync Committees
   * [ ] Database: table sync_committees (Sync Committee index)

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -64,6 +64,7 @@ func startFrontend() {
 	router.HandleFunc("/search", handlers.Search).Methods("GET")
 	router.HandleFunc("/search/{type}", handlers.SearchAhead).Methods("GET")
 	router.HandleFunc("/validators", handlers.Validators).Methods("GET")
+	router.HandleFunc("/validator/{idxOrPubKey}", handlers.Validator).Methods("GET")
 
 	if utils.Config.Frontend.Debug {
 		// serve files from local directory when debugging, instead of from go embed file

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -63,6 +63,7 @@ func startFrontend() {
 	router.HandleFunc("/slot/{slotOrHash}", handlers.Slot).Methods("GET")
 	router.HandleFunc("/search", handlers.Search).Methods("GET")
 	router.HandleFunc("/search/{type}", handlers.SearchAhead).Methods("GET")
+	router.HandleFunc("/validators", handlers.Validators).Methods("GET")
 
 	if utils.Config.Frontend.Debug {
 		// serve files from local directory when debugging, instead of from go embed file

--- a/config/default.config.yml
+++ b/config/default.config.yml
@@ -3,7 +3,6 @@
 chain:
   name: "mainnet"
   #genesisTimestamp: 1688126460
-  #genesisValidatorsRoot: "0xbf3c3d4683a5a4d286cd2a5ef7a5c1702f649eee82cdc7e87e05030102d12ccf"
   #configPath: "../ephemery/config.yaml"
   #displayName: "Ephemery Iteration xy"
 
@@ -31,10 +30,10 @@ beaconapi:
   # CL Client RPC
   endpoint: "http://127.0.0.1:5052"
 
-  # local cache for RPC calls
+  # local cache for page models
   localCacheSize: 100 # 100MB
 
-  # remote cache for RPC calls & page models
+  # remote cache for page models
   redisCacheAddr: ""
   redisCachePrefix: ""
 

--- a/dbtypes/other.go
+++ b/dbtypes/other.go
@@ -1,0 +1,7 @@
+package dbtypes
+
+type AssignedBlock struct {
+	Slot     uint64 `db:"slot"`
+	Proposer uint64 `db:"proposer"`
+	Block    *Block `db:"block"`
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+require github.com/mitchellh/mapstructure v1.5.0 // indirect
+
 require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=

--- a/handlers/pageData.go
+++ b/handlers/pageData.go
@@ -103,6 +103,15 @@ func createMenuItems(active string, isMain bool) []types.MainMenuItem {
 						},
 					},
 				},
+				{
+					Links: []types.NavigationLink{
+						{
+							Label: "Validators",
+							Path:  "/validators",
+							Icon:  "fa-table",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -23,6 +23,8 @@ import (
 func Validator(w http.ResponseWriter, r *http.Request) {
 	var validatorTemplateFiles = append(layoutTemplateFiles,
 		"validator/validator.html",
+		"validator/recentBlocks.html",
+		"_svg/timeline.html",
 	)
 	var notfoundTemplateFiles = append(layoutTemplateFiles,
 		"validator/notfound.html",
@@ -71,8 +73,8 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getValidatorPageData(validatorIndex uint64) *models.ValidatorsPageData {
-	pageData := &models.ValidatorsPageData{}
+func getValidatorPageData(validatorIndex uint64) *models.ValidatorPageData {
+	pageData := &models.ValidatorPageData{}
 	pageCacheKey := fmt.Sprintf("validator:%v", validatorIndex)
 	if !utils.Config.Frontend.Debug && services.GlobalBeaconService.GetFrontendCache(pageCacheKey, pageData) == nil {
 		logrus.Printf("validator page served from cache: %v", validatorIndex)
@@ -80,7 +82,90 @@ func getValidatorPageData(validatorIndex uint64) *models.ValidatorsPageData {
 	}
 	logrus.Printf("validator page called: %v", validatorIndex)
 
-	// TODO
+	validatorSetRsp := services.GlobalBeaconService.GetCachedValidatorSet()
+	validator := validatorSetRsp.Data[validatorIndex]
+
+	pageData = &models.ValidatorPageData{
+		CurrentEpoch:        uint64(utils.TimeToEpoch(time.Now())),
+		Index:               uint64(validator.Index),
+		Name:                services.GlobalBeaconService.GetValidatorName(uint64(validator.Index)),
+		PublicKey:           validator.Validator.PubKey,
+		Balance:             uint64(validator.Balance),
+		EffectiveBalance:    uint64(validator.Validator.EffectiveBalance),
+		BeaconState:         validator.Status,
+		WithdrawCredentials: validator.Validator.WithdrawalCredentials,
+	}
+	if strings.HasPrefix(validator.Status, "pending") {
+		pageData.State = "Pending"
+	} else if validator.Status == "active_ongoing" {
+		pageData.State = "Active"
+		pageData.IsActive = true
+	} else if validator.Status == "active_exiting" {
+		pageData.State = "Exiting"
+		pageData.IsActive = true
+	} else if validator.Status == "active_slashed" {
+		pageData.State = "Slashed"
+		pageData.IsActive = true
+	} else if validator.Status == "exited_unslashed" {
+		pageData.State = "Exited"
+	} else if validator.Status == "exited_slashed" {
+		pageData.State = "Slashed"
+	} else {
+		pageData.State = validator.Status
+	}
+
+	if pageData.IsActive {
+		// load activity map
+		activityMap, maxActivity := services.GlobalBeaconService.GetValidatorActivity()
+		pageData.UpcheckActivity = activityMap[uint64(validator.Index)]
+		pageData.UpcheckMaximum = uint8(maxActivity)
+	}
+
+	if validator.Validator.ActivationEligibilityEpoch < 18446744073709551615 {
+		pageData.ShowEligible = true
+		pageData.EligibleEpoch = uint64(validator.Validator.ActivationEligibilityEpoch)
+		pageData.EligibleTs = utils.EpochToTime(uint64(validator.Validator.ActivationEligibilityEpoch))
+	}
+	if validator.Validator.ActivationEpoch < 18446744073709551615 {
+		pageData.ShowActivation = true
+		pageData.ActivationEpoch = uint64(validator.Validator.ActivationEpoch)
+		pageData.ActivationTs = utils.EpochToTime(uint64(validator.Validator.ActivationEpoch))
+	}
+	if validator.Validator.ExitEpoch < 18446744073709551615 {
+		pageData.ShowExit = true
+		pageData.WasActive = true
+		pageData.ExitEpoch = uint64(validator.Validator.ExitEpoch)
+		pageData.ExitTs = utils.EpochToTime(uint64(validator.Validator.ExitEpoch))
+	}
+	if validator.Validator.WithdrawalCredentials[0] == 0x01 {
+		pageData.ShowWithdrawAddress = true
+		pageData.WithdrawAddress = validator.Validator.WithdrawalCredentials[12:]
+	}
+
+	// load latest blocks
+	pageData.RecentBlocks = make([]*models.ValidatorPageDataBlocks, 0)
+	blocksData := services.GlobalBeaconService.GetDbBlocksByProposer(validatorIndex, 0, 10, true, true)
+	for _, blockData := range blocksData {
+		blockStatus := 1
+		if blockData.Block == nil {
+			blockStatus = 0
+		} else if blockData.Block.Orphaned {
+			blockStatus = 2
+		}
+		blockEntry := models.ValidatorPageDataBlocks{
+			Epoch:  utils.EpochOfSlot(blockData.Slot),
+			Slot:   blockData.Slot,
+			Ts:     utils.SlotToTime(blockData.Slot),
+			Status: uint64(blockStatus),
+		}
+		if blockData.Block != nil {
+			blockEntry.Graffiti = blockData.Block.Graffiti
+			blockEntry.EthBlock = blockData.Block.EthBlockNumber
+			blockEntry.BlockRoot = fmt.Sprintf("0x%x", blockData.Block.Root)
+		}
+		pageData.RecentBlocks = append(pageData.RecentBlocks, &blockEntry)
+	}
+	pageData.RecentBlockCount = uint64(len(pageData.RecentBlocks))
 
 	if pageCacheKey != "" {
 		services.GlobalBeaconService.SetFrontendCache(pageCacheKey, pageData, 10*time.Minute)

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+
+	"github.com/pk910/light-beaconchain-explorer/rpctypes"
+	"github.com/pk910/light-beaconchain-explorer/services"
+	"github.com/pk910/light-beaconchain-explorer/templates"
+	"github.com/pk910/light-beaconchain-explorer/types/models"
+	"github.com/pk910/light-beaconchain-explorer/utils"
+)
+
+// Validator will return the main "validator" page using a go template
+func Validator(w http.ResponseWriter, r *http.Request) {
+	var validatorTemplateFiles = append(layoutTemplateFiles,
+		"validator/validator.html",
+	)
+	var notfoundTemplateFiles = append(layoutTemplateFiles,
+		"validator/notfound.html",
+	)
+
+	var pageTemplate = templates.GetTemplate(validatorTemplateFiles...)
+
+	w.Header().Set("Content-Type", "text/html")
+	data := InitPageData(w, r, "validators", "/validator", "Validator", validatorTemplateFiles)
+
+	validatorSetRsp := services.GlobalBeaconService.GetCachedValidatorSet()
+	var validator *rpctypes.ValidatorEntry
+	if validatorSetRsp != nil {
+		vars := mux.Vars(r)
+		idxOrPubKey := strings.Replace(vars["idxOrPubKey"], "0x", "", -1)
+		validatorPubKey, err := hex.DecodeString(idxOrPubKey)
+		if err != nil || len(validatorPubKey) != 48 {
+			// search by index^
+			validatorIndex, err := strconv.ParseUint(vars["idxOrPubKey"], 10, 64)
+			if err == nil && validatorIndex < uint64(len(validatorSetRsp.Data)) {
+				validator = &validatorSetRsp.Data[validatorIndex]
+			}
+		} else {
+			// search by pubkey
+			for _, val := range validatorSetRsp.Data {
+				if bytes.Equal(val.Validator.PubKey, validatorPubKey) {
+					validator = &val
+					break
+				}
+			}
+		}
+	}
+
+	if validator == nil {
+		data := InitPageData(w, r, "blockchain", "/validator", "Validator not found", notfoundTemplateFiles)
+		if handleTemplateError(w, r, "validator.go", "Validator", "", templates.GetTemplate(notfoundTemplateFiles...).ExecuteTemplate(w, "layout", data)) != nil {
+			return // an error has occurred and was processed
+		}
+		return
+	}
+
+	data.Data = getValidatorPageData(uint64(validator.Index))
+
+	if handleTemplateError(w, r, "validators.go", "Validators", "", pageTemplate.ExecuteTemplate(w, "layout", data)) != nil {
+		return // an error has occurred and was processed
+	}
+}
+
+func getValidatorPageData(validatorIndex uint64) *models.ValidatorsPageData {
+	pageData := &models.ValidatorsPageData{}
+	pageCacheKey := fmt.Sprintf("validator:%v", validatorIndex)
+	if !utils.Config.Frontend.Debug && services.GlobalBeaconService.GetFrontendCache(pageCacheKey, pageData) == nil {
+		logrus.Printf("validator page served from cache: %v", validatorIndex)
+		return pageData
+	}
+	logrus.Printf("validator page called: %v", validatorIndex)
+
+	// TODO
+
+	if pageCacheKey != "" {
+		services.GlobalBeaconService.SetFrontendCache(pageCacheKey, pageData, 10*time.Minute)
+	}
+	return pageData
+}

--- a/handlers/validators.go
+++ b/handlers/validators.go
@@ -1,0 +1,172 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pk910/light-beaconchain-explorer/services"
+	"github.com/pk910/light-beaconchain-explorer/templates"
+	"github.com/pk910/light-beaconchain-explorer/types/models"
+	"github.com/pk910/light-beaconchain-explorer/utils"
+	"github.com/sirupsen/logrus"
+)
+
+// Validators will return the main "validators" page using a go template
+func Validators(w http.ResponseWriter, r *http.Request) {
+	var validatorsTemplateFiles = append(layoutTemplateFiles,
+		"validators/validators.html",
+		"_svg/professor.html",
+	)
+
+	var pageTemplate = templates.GetTemplate(validatorsTemplateFiles...)
+
+	w.Header().Set("Content-Type", "text/html")
+	data := InitPageData(w, r, "validators", "/validators", "Validators", validatorsTemplateFiles)
+
+	urlArgs := r.URL.Query()
+	var firstIdx uint64 = 0
+	if urlArgs.Has("s") {
+		firstIdx, _ = strconv.ParseUint(urlArgs.Get("s"), 10, 64)
+	}
+	var pageSize uint64 = 50
+	if urlArgs.Has("c") {
+		pageSize, _ = strconv.ParseUint(urlArgs.Get("c"), 10, 64)
+	}
+	var stateFilter string
+	if urlArgs.Has("q") {
+		stateFilter = urlArgs.Get("q")
+	}
+	data.Data = getValidatorsPageData(firstIdx, pageSize, stateFilter)
+
+	if handleTemplateError(w, r, "validators.go", "Validators", "", pageTemplate.ExecuteTemplate(w, "layout", data)) != nil {
+		return // an error has occurred and was processed
+	}
+}
+
+func getValidatorsPageData(firstValIdx uint64, pageSize uint64, stateFilter string) *models.ValidatorsPageData {
+	pageData := &models.ValidatorsPageData{}
+	pageCacheKey := fmt.Sprintf("validators:%v:%v:%v", firstValIdx, pageSize, stateFilter)
+	if !utils.Config.Frontend.Debug && services.GlobalBeaconService.GetFrontendCache(pageCacheKey, pageData) == nil {
+		logrus.Printf("validators page served from cache: %v:%v", firstValIdx, pageSize)
+		return pageData
+	}
+	logrus.Printf("validators page called: %v:%v:%v", firstValIdx, pageSize, stateFilter)
+
+	// get latest validator set
+	validatorSetRsp := services.GlobalBeaconService.GetCachedValidatorSet()
+	if validatorSetRsp == nil {
+		return pageData
+	}
+	validatorSet := validatorSetRsp.Data
+	if stateFilter != "" {
+		// TODO: apply filter
+	}
+
+	totalValidatorCount := uint64(len(validatorSet))
+	if firstValIdx == 0 {
+		pageData.IsDefaultPage = true
+	} else if firstValIdx > totalValidatorCount {
+		firstValIdx = totalValidatorCount
+	}
+
+	if pageSize > 100 {
+		pageSize = 100
+	}
+
+	pagesBefore := firstValIdx / pageSize
+	if (firstValIdx % pageSize) > 0 {
+		pagesBefore++
+	}
+	pagesAfter := (totalValidatorCount - firstValIdx) / pageSize
+	if ((totalValidatorCount - firstValIdx) % pageSize) > 0 {
+		pagesAfter++
+	}
+	pageData.PageSize = pageSize
+	pageData.TotalPages = pagesBefore + pagesAfter
+	pageData.CurrentPageIndex = pagesBefore + 1
+	pageData.CurrentPageValIdx = firstValIdx
+	if pagesBefore > 0 {
+		pageData.PrevPageIndex = pageData.CurrentPageIndex - 1
+		pageData.PrevPageValIdx = pageData.CurrentPageValIdx - pageSize
+	}
+	if pagesAfter > 1 {
+		pageData.NextPageIndex = pageData.CurrentPageIndex + 1
+		pageData.NextPageValIdx = pageData.CurrentPageValIdx + pageSize
+	}
+	pageData.LastPageValIdx = totalValidatorCount - pageSize
+
+	// load activity map
+	activityMap, maxActivity := services.GlobalBeaconService.GetValidatorActivity(2, true)
+
+	// get validators
+	lastValIdx := firstValIdx + pageSize
+	if lastValIdx >= totalValidatorCount {
+		lastValIdx = totalValidatorCount
+	}
+	pageData.Validators = make([]*models.ValidatorsPageDataValidator, 0)
+
+	for _, validator := range validatorSet[firstValIdx:lastValIdx] {
+		validatorData := &models.ValidatorsPageDataValidator{
+			Index:            uint64(validator.Index),
+			Name:             services.GlobalBeaconService.GetValidatorName(uint64(validator.Index)),
+			PublicKey:        validator.Validator.PubKey,
+			Balance:          uint64(validator.Balance),
+			EffectiveBalance: uint64(validator.Validator.EffectiveBalance),
+		}
+		if strings.HasPrefix(validator.Status, "pending") {
+			validatorData.State = "Pending"
+		} else if validator.Status == "active_ongoing" {
+			validatorData.State = "Active"
+			validatorData.ShowUpcheck = true
+		} else if validator.Status == "active_exiting" {
+			validatorData.State = "Exiting"
+			validatorData.ShowUpcheck = true
+		} else if validator.Status == "active_slashed" {
+			validatorData.State = "Slashed"
+			validatorData.ShowUpcheck = true
+		} else if validator.Status == "exited_unslashed" {
+			validatorData.State = "Exited"
+		} else if validator.Status == "exited_slashed" {
+			validatorData.State = "Slashed"
+		} else {
+			validatorData.State = validator.Status
+		}
+
+		if validatorData.ShowUpcheck {
+			activity := activityMap[uint64(validator.Index)]
+			if activity == uint8(maxActivity) {
+				validatorData.UpcheckState = 2
+			} else if activity > 0 {
+				validatorData.UpcheckState = 1
+			}
+		}
+
+		if validator.Validator.ActivationEpoch < 18446744073709551615 {
+			validatorData.ShowActivation = true
+			validatorData.ActivationEpoch = uint64(validator.Validator.ActivationEpoch)
+			validatorData.ActivationTs = utils.EpochToTime(uint64(validator.Validator.ActivationEpoch))
+		}
+		if validator.Validator.ExitEpoch < 18446744073709551615 {
+			validatorData.ShowExit = true
+			validatorData.ExitEpoch = uint64(validator.Validator.ExitEpoch)
+			validatorData.ExitTs = utils.EpochToTime(uint64(validator.Validator.ExitEpoch))
+		}
+		if validator.Validator.WithdrawalCredentials[0] == 0x01 {
+			validatorData.ShowWithdrawAddress = true
+			validatorData.WithdrawAddress = validator.Validator.WithdrawalCredentials[12:]
+		}
+
+		pageData.Validators = append(pageData.Validators, validatorData)
+	}
+	pageData.ValidatorCount = uint64(len(pageData.Validators))
+	pageData.FirstValidator = firstValIdx
+	pageData.LastValidator = lastValIdx
+
+	if pageCacheKey != "" {
+		services.GlobalBeaconService.SetFrontendCache(pageCacheKey, pageData, 10*time.Minute)
+	}
+	return pageData
+}

--- a/handlers/validators.go
+++ b/handlers/validators.go
@@ -99,7 +99,7 @@ func getValidatorsPageData(firstValIdx uint64, pageSize uint64, stateFilter stri
 	pageData.LastPageValIdx = totalValidatorCount - pageSize
 
 	// load activity map
-	activityMap, maxActivity := services.GlobalBeaconService.GetValidatorActivity(2, true)
+	activityMap, maxActivity := services.GlobalBeaconService.GetValidatorActivity()
 
 	// get validators
 	lastValIdx := firstValIdx + pageSize
@@ -136,12 +136,8 @@ func getValidatorsPageData(firstValIdx uint64, pageSize uint64, stateFilter stri
 		}
 
 		if validatorData.ShowUpcheck {
-			activity := activityMap[uint64(validator.Index)]
-			if activity == uint8(maxActivity) {
-				validatorData.UpcheckState = 2
-			} else if activity > 0 {
-				validatorData.UpcheckState = 1
-			}
+			validatorData.UpcheckActivity = activityMap[uint64(validator.Index)]
+			validatorData.UpcheckMaximum = uint8(maxActivity)
 		}
 
 		if validator.Validator.ActivationEpoch < 18446744073709551615 {

--- a/indexer/votes.go
+++ b/indexer/votes.go
@@ -18,6 +18,7 @@ type EpochVotes struct {
 		headVoteAmount   uint64
 		totalVoteAmount  uint64
 	}
+	ActivityMap map[uint64]bool
 }
 
 func aggregateEpochVotes(blockMap map[uint64][]*BlockInfo, epoch uint64, epochStats *EpochStats, targetRoot []byte, currentOnly bool) *EpochVotes {
@@ -28,7 +29,9 @@ func aggregateEpochVotes(blockMap map[uint64][]*BlockInfo, epoch uint64, epochSt
 		lastSlot += utils.Config.Chain.Config.SlotsPerEpoch
 	}
 
-	votes := EpochVotes{}
+	votes := EpochVotes{
+		ActivityMap: map[uint64]bool{},
+	}
 	votedBitsets := make(map[string][]byte)
 
 	for slot := firstSlot; slot <= lastSlot; slot++ {
@@ -59,6 +62,7 @@ func aggregateEpochVotes(blockMap map[uint64][]*BlockInfo, epoch uint64, epochSt
 							}
 							if utils.BitAtVector(voteBitset, bitIdx) {
 								voteAmount += uint64(epochStats.Validators.ValidatorBalances[validatorIdx])
+								votes.ActivityMap[validatorIdx] = true
 							}
 						}
 					}

--- a/rpctypes/beaconapi.go
+++ b/rpctypes/beaconapi.go
@@ -79,12 +79,7 @@ type EpochAssignments struct {
 }
 
 type StandardV1StateValidatorsResponse struct {
-	Data []struct {
-		Index     Uint64Str `json:"index"`
-		Balance   Uint64Str `json:"balance"`
-		Status    string    `json:"status"`
-		Validator Validator `json:"validator"`
-	} `json:"data"`
+	Data []ValidatorEntry `json:"data"`
 }
 
 type StandardV1GenesisResponse struct {

--- a/rpctypes/beacontypes.go
+++ b/rpctypes/beacontypes.go
@@ -165,6 +165,13 @@ type Validator struct {
 	WithdrawableEpoch          Uint64Str   `json:"withdrawable_epoch"`
 }
 
+type ValidatorEntry struct {
+	Index     Uint64Str `json:"index"`
+	Balance   Uint64Str `json:"balance"`
+	Status    string    `json:"status"`
+	Validator Validator `json:"validator"`
+}
+
 type BlobSidecar struct {
 	BlockRoot       BytesHexStr `json:"block_root"`
 	Index           Uint64Str   `json:"index"`

--- a/services/beaconservice.go
+++ b/services/beaconservice.go
@@ -3,6 +3,7 @@ package services
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pk910/light-beaconchain-explorer/cache"
@@ -19,6 +20,13 @@ type BeaconService struct {
 	frontendCache  *cache.TieredCache
 	indexer        *indexer.Indexer
 	validatorNames *ValidatorNames
+
+	validatorActivityMutex sync.Mutex
+	validatorActivityStats struct {
+		cacheEpoch uint64
+		epochLimit uint64
+		activity   map[uint64]uint8
+	}
 }
 
 var GlobalBeaconService *BeaconService
@@ -485,67 +493,169 @@ func (bs *BeaconService) GetDbBlocksByGraffiti(graffiti string, pageIdx uint64, 
 	return resBlocks
 }
 
-func (bs *BeaconService) GetValidatorActivity(epochLimit uint64, skipCurrent bool) (map[uint64]uint8, uint64) {
+func (bs *BeaconService) GetDbBlocksByProposer(proposer uint64, pageIdx uint64, pageSize uint32, withMissing bool, withOrphaned bool) []*dbtypes.AssignedBlock {
+	cachedMatches := make([]struct {
+		slot  uint64
+		block *indexer.BlockInfo
+	}, 0)
+	idxMinSlot := bs.indexer.GetLowestCachedSlot()
+	idxHeadSlot := bs.indexer.GetHeadSlot()
+	if idxMinSlot >= 0 {
+		idxHeadEpoch := utils.EpochOfSlot(idxHeadSlot)
+		idxMinEpoch := utils.EpochOfSlot(uint64(idxMinSlot))
+		for epochIdx := int64(idxHeadEpoch); epochIdx >= int64(idxMinEpoch); epochIdx-- {
+			epoch := uint64(epochIdx)
+			epochStats := bs.indexer.GetCachedEpochStats(epoch)
+			if epochStats == nil || epochStats.Assignments == nil {
+				continue
+			}
+
+			for slot, assigned := range epochStats.Assignments.ProposerAssignments {
+				if assigned != proposer {
+					continue
+				}
+				blocks := bs.indexer.GetCachedBlocks(slot)
+				haveBlock := false
+				if blocks != nil {
+					for bidx := 0; bidx < len(blocks); bidx++ {
+						block := blocks[bidx]
+						if block.Orphaned && !withOrphaned {
+							continue
+						}
+						if uint64(block.Block.Data.Message.ProposerIndex) != proposer {
+							continue
+						}
+						cachedMatches = append(cachedMatches, struct {
+							slot  uint64
+							block *indexer.BlockInfo
+						}{
+							slot:  slot,
+							block: block,
+						})
+						haveBlock = true
+					}
+				}
+				if !haveBlock && withMissing {
+					cachedMatches = append(cachedMatches, struct {
+						slot  uint64
+						block *indexer.BlockInfo
+					}{
+						slot:  slot,
+						block: nil,
+					})
+				}
+			}
+
+		}
+	}
+
+	cachedMatchesLen := uint64(len(cachedMatches))
+	cachedPages := cachedMatchesLen / uint64(pageSize)
+	resBlocks := make([]*dbtypes.AssignedBlock, 0)
+	resIdx := 0
+
+	cachedStart := pageIdx * uint64(pageSize)
+	cachedEnd := cachedStart + uint64(pageSize)
+	if cachedEnd+1 < cachedMatchesLen {
+		cachedEnd++
+	}
+
+	if cachedPages > 0 && pageIdx < cachedPages {
+		for _, block := range cachedMatches[cachedStart:cachedEnd] {
+			assignedBlock := dbtypes.AssignedBlock{
+				Slot:     block.slot,
+				Proposer: proposer,
+			}
+			if block.block != nil {
+				assignedBlock.Block = bs.indexer.BuildLiveBlock(block.block)
+			}
+			resBlocks = append(resBlocks, &assignedBlock)
+
+			resIdx++
+		}
+	} else if pageIdx == cachedPages {
+		start := pageIdx * uint64(pageSize)
+		for _, block := range cachedMatches[start:] {
+			assignedBlock := dbtypes.AssignedBlock{
+				Slot:     block.slot,
+				Proposer: proposer,
+			}
+			if block.block != nil {
+				assignedBlock.Block = bs.indexer.BuildLiveBlock(block.block)
+			}
+			resBlocks = append(resBlocks, &assignedBlock)
+			resIdx++
+		}
+	}
+	if resIdx > int(pageSize) {
+		return resBlocks
+	}
+
+	// load from db
+	var dbMinSlot uint64
+	if idxMinSlot < 0 {
+		dbMinSlot = utils.TimeToSlot(uint64(time.Now().Unix()))
+	} else {
+		dbMinSlot = uint64(idxMinSlot)
+	}
+
+	dbPage := pageIdx - cachedPages
+	dbCacheOffset := uint64(pageSize) - (cachedMatchesLen % uint64(pageSize))
+	var dbBlocks []*dbtypes.AssignedBlock
+	if dbPage == 0 {
+		dbBlocks = db.GetAssignedBlocks(proposer, dbMinSlot, 0, uint32(dbCacheOffset)+1, withOrphaned)
+	} else {
+		dbBlocks = db.GetAssignedBlocks(proposer, dbMinSlot, (dbPage-1)*uint64(pageSize)+dbCacheOffset, pageSize+1, withOrphaned)
+	}
+	if dbBlocks != nil {
+		for _, dbBlock := range dbBlocks {
+			resBlocks = append(resBlocks, dbBlock)
+		}
+	}
+
+	return resBlocks
+}
+
+func (bs *BeaconService) GetValidatorActivity() (map[uint64]uint8, uint64) {
 	activityMap := map[uint64]uint8{}
+	epochLimit := uint64(3)
 
 	idxHeadSlot := bs.indexer.GetHeadSlot()
 	idxHeadEpoch := utils.EpochOfSlot(idxHeadSlot)
-	if skipCurrent && idxHeadEpoch > 0 {
-		idxHeadEpoch--
-		idxHeadSlot = (idxHeadEpoch * utils.Config.Chain.Config.SlotsPerEpoch) + (utils.Config.Chain.Config.SlotsPerEpoch - 1)
+	if idxHeadEpoch < 1 {
+		return activityMap, 0
 	}
+	idxHeadEpoch--
 	idxMinSlot := bs.indexer.GetLowestCachedSlot()
 	if idxMinSlot < 0 {
 		return activityMap, 0
 	}
 	idxMinEpoch := utils.EpochOfSlot(uint64(idxMinSlot))
-	if idxHeadEpoch-idxMinEpoch < epochLimit {
-		epochLimit = idxHeadEpoch - idxMinEpoch
-	}
-	minSlot := (idxHeadEpoch - epochLimit) * utils.Config.Chain.Config.SlotsPerEpoch
-	votedBitsets := make(map[string][]byte)
 
-	for slotIdx := int64(minSlot); slotIdx >= int64(minSlot); slotIdx-- {
-		slot := uint64(slotIdx)
-		epoch := utils.EpochOfSlot(slot)
-		epochStats := bs.indexer.GetCachedEpochStats(epoch)
-		if epochStats == nil || epochStats.Assignments == nil {
-			continue
-		}
-		blocks := bs.indexer.GetCachedBlocks(slot)
-		if blocks != nil {
-			for bidx := 0; bidx < len(blocks); bidx++ {
-				block := blocks[bidx]
-				if block.Orphaned {
-					continue
-				}
-				for _, att := range block.Block.Data.Message.Body.Attestations {
-					attKey := fmt.Sprintf("%v-%v", uint64(att.Data.Slot), uint64(att.Data.Index))
-					validators := epochStats.Assignments.AttestorAssignments[attKey]
-					votedBitset := votedBitsets[attKey]
-					if validators != nil {
-						for bitIdx, valIdx := range validators {
-							if votedBitset != nil && utils.BitAtVector(votedBitset, bitIdx) {
-								continue
-							}
-							if utils.BitAtVector(att.AggregationBits, bitIdx) {
-								activityMap[valIdx]++
-							}
-						}
-						if votedBitset != nil {
-							// merge bitsets
-							for i := 0; i < len(votedBitset); i++ {
-								votedBitset[i] |= att.AggregationBits[i]
-							}
-						} else {
-							votedBitset = make([]byte, len(att.AggregationBits))
-							copy(votedBitset, att.AggregationBits)
-							votedBitsets[attKey] = att.AggregationBits
-						}
-					}
-				}
-			}
+	activityEpoch := utils.EpochOfSlot(idxHeadSlot - 1)
+	bs.validatorActivityMutex.Lock()
+	defer bs.validatorActivityMutex.Unlock()
+	if bs.validatorActivityStats.activity != nil && bs.validatorActivityStats.cacheEpoch == activityEpoch {
+		return bs.validatorActivityStats.activity, bs.validatorActivityStats.epochLimit
+	}
+
+	actualEpochCount := idxHeadEpoch - idxMinEpoch + 1
+	if actualEpochCount > epochLimit {
+		idxMinEpoch = idxHeadEpoch - epochLimit
+	} else if actualEpochCount < epochLimit {
+		epochLimit = actualEpochCount
+	}
+
+	for epochIdx := int64(idxHeadEpoch); epochIdx >= int64(idxMinEpoch); epochIdx-- {
+		epoch := uint64(epochIdx)
+		epochVotes := bs.indexer.GetEpochVotes(epoch)
+		for valIdx := range epochVotes.ActivityMap {
+			activityMap[valIdx]++
 		}
 	}
+
+	bs.validatorActivityStats.cacheEpoch = activityEpoch
+	bs.validatorActivityStats.epochLimit = epochLimit
+	bs.validatorActivityStats.activity = activityMap
 	return activityMap, epochLimit
 }

--- a/services/beaconservice.go
+++ b/services/beaconservice.go
@@ -641,7 +641,7 @@ func (bs *BeaconService) GetValidatorActivity() (map[uint64]uint8, uint64) {
 
 	actualEpochCount := idxHeadEpoch - idxMinEpoch + 1
 	if actualEpochCount > epochLimit {
-		idxMinEpoch = idxHeadEpoch - epochLimit
+		idxMinEpoch = idxHeadEpoch - epochLimit + 1
 	} else if actualEpochCount < epochLimit {
 		epochLimit = actualEpochCount
 	}

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -267,3 +267,8 @@ span.validator-label {
       border: hidden;
   }
 }
+
+.text-truncate {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}

--- a/static/css/validator.css
+++ b/static/css/validator.css
@@ -1,0 +1,215 @@
+/* begin validator lifecycle */
+.validator__lifecycle-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin: 24px 20px 8px 20px;
+  font-size: .85rem;
+}
+.validator__lifecycle-content {
+  display: flex;
+  max-width: 600px;
+  width: 100%;
+}
+.validator__lifecycle-node-container {
+  position: relative;
+}
+.validator__lifecycle-node-header {
+  position: absolute;
+  top: -28px;
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 60%;
+}
+.validator__lifecycle-node::before {
+  content: '';
+  position: absolute;
+  opacity: 20%;
+  height: 8px;
+  border-right: solid 1px var(--bs-body-color, black);
+  top: -12px;
+}
+.validator__lifecycle-node {
+  width: 18px;
+  height: 18px;
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  border: solid 4px var(--bs-tertiary-color, #00000033);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.validator__lifecycle-node, .validator__lifecycle-node > * {
+  box-sizing: content-box;
+}
+.validator__lifecycle-progress {
+  position: relative;
+  flex: 1 1 20px;
+}
+.validator__lifecycle-progress::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-bottom: solid 1px var(--bs-body-color, black);
+  width: 85%;
+  opacity: 20%;
+}
+.validator__lifecycle-progress-epoch {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: -10px;
+  color: black;
+  width: 85%;
+  font-size: 90%;
+}
+.validator__lifecycle-progress-epoch > div {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+.validator__lifecycle-container .validator__lifecycle-progress::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+}
+.validator__lifecycle-container .active.validator__lifecycle-progress::after {
+  position: absolute;
+  left: 7.5%;
+  border-bottom: solid 1px var(--bs-body-color, black);
+  width: 45%;
+}
+.validator__lifecycle-container .complete.validator__lifecycle-progress::after {
+  position: absolute;
+  border-bottom: solid 1px var(--bs-body-color, black);
+  left: 7.5%;
+  width: 85%;
+}
+.validator__lifecycle-container .active .validator__lifecycle-node-header,
+.validator__lifecycle-container .failed .validator__lifecycle-node-header,
+.validator__lifecycle-container .online .validator__lifecycle-node-header,
+.validator__lifecycle-container .offline .validator__lifecycle-node-header,
+.validator__lifecycle-container .done .validator__lifecycle-node-header {
+  opacity: 1;
+}
+.validator__lifecycle-container .done .validator__lifecycle-node,
+.validator__lifecycle-container .online.validator__lifecycle-active .validator__lifecycle-node {
+  border-color: var(--success, green);
+  background-color: var(--success, green);
+}
+.validator__lifecycle-container .failed .validator__lifecycle-node,
+.validator__lifecycle-container .offline.validator__lifecycle-active .validator__lifecycle-node {
+  border-color: var(--red);
+  background-color: var(--red);
+}
+.validator__lifecycle-container i {
+  visibility: hidden;
+  position: absolute;
+  color: white;
+}
+.validator__lifecycle-container .done.validator__lifecycle-deposited .deposit-success,
+.validator__lifecycle-container .failed.validator__lifecycle-deposited .deposit-fail,
+.validator__lifecycle-container .done .fa-check,
+.validator__lifecycle-container .done .fa-door-open,
+.validator__lifecycle-container .failed .fa-door-open,
+.validator__lifecycle-container .online.validator__lifecycle-active .online,
+.validator__lifecycle-container .offline.validator__lifecycle-active .offline {
+  visibility: visible;
+} 
+.validator__lifecycle-container .spinner {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+.validator__lifecycle-container .double-bounce1,
+.validator__lifecycle-container .double-bounce2 {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background-color: #219653;
+  opacity: 0.6;
+  top: 0;
+  left: 0;
+  visibility: hidden;
+  -webkit-animation: sk-bounce 3.0s infinite ease-in-out;
+  animation: sk-bounce 3.0s infinite ease-in-out;
+}
+.validator__lifecycle-container .active .double-bounce1,
+.validator__lifecycle-container .active .double-bounce2 {
+  visibility: visible;
+}
+.validator__lifecycle-container .active.slashed .double-bounce1,
+.validator__lifecycle-container .active.slashed .double-bounce2 {
+  background-color: var(--red);
+}
+.validator__lifecycle-container .active .double-bounce2 {
+  -webkit-animation-delay: -1.5s;
+  animation-delay: -1.5s;
+}
+@-webkit-keyframes sk-bounce {
+  0%,
+  100% {
+    -webkit-transform: scale(0.0);
+  }
+
+  50% {
+    -webkit-transform: scale(1.5);
+  }
+}
+@keyframes sk-bounce {
+  0%,
+  100% {
+    transform: scale(0.0);
+    -webkit-transform: scale(0.0);
+  }
+
+  50% {
+    transform: scale(1.5);
+    -webkit-transform: scale(1.5);
+  }
+}
+@media screen and (min-width: 960px) {
+  .validator__lifecycle-container i {
+    margin-bottom: 0;
+  }
+  .validator__lifecycle-progress-epoch {
+    bottom: -2px;
+  }
+  .validator__lifecycle-node {
+    width: 24px;
+    height: 24px;
+    border-width: 5px;
+  }
+}
+/* end validator lifecycle */
+
+/* responsive tabs for mobile screens (shows icons when tab is not selected and text when selected */
+@media screen and (max-width: 1450px) {
+  .validator__lifecycle-container {
+    width: 80%;
+  }
+  .nav-tabs .tab-text {
+    display: none;
+  }
+  .nav-tabs .active .tab-text {
+    display: initial;
+  }
+  .nav-tabs .active .tab-icon {
+    display: none;
+  }
+  .nav-tabs .active i {
+    margin-right: .25rem;
+  }
+  .nav-tabs .tab-text + .badge {
+    display: none;
+  }
+}
+.validator-card {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/templates/validator/notfound.html
+++ b/templates/validator/notfound.html
@@ -1,0 +1,27 @@
+{{ define "js" }}
+{{ end }}
+
+{{ define "css" }}
+{{ end }}
+
+{{ define "page" }}
+  <div class="container mt-2">
+    <div class="my-3">
+      <div class="d-md-flex py-2 justify-content-md-between">
+        <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-cube mr-2"></i>Validator not found</h1>
+        <nav aria-label="breadcrumb">
+          <ol class="breadcrumb font-size-1 mb-0" style="padding:0; background-color:transparent;">
+            <li class="breadcrumb-item"><a href="/" title="Home">Home</a></li>
+            <li class="breadcrumb-item"><a href="/validators" title="Validators">Validators</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Validator details</li>
+          </ol>
+        </nav>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-body">
+        <div class="d-1">Sorry but we could not find the validator you are looking for</div>
+      </div>
+    </div>
+  </div>
+{{ end }}

--- a/templates/validator/recentAttestations.html
+++ b/templates/validator/recentAttestations.html
@@ -1,0 +1,38 @@
+{{ define "recentAttestations" }}
+  <div class="card">
+    <div class="card-header">
+      <h3 class="card-title d-flex justify-content-between align-items-center" style="margin: .5rem 0;">
+        <span><i class="fa fa-cubes"></i> Most recent attestations</span>
+      </h3>
+    </div>
+    <div class="card-body p-0">
+      <div class="table-responsive">
+        <table class="table table-nobr" id="recent-blocks">
+          <thead>
+            <tr>
+              <th>Epoch</th>
+              <th>Slot</th>
+              <th data-toggle="tooltip" title="Execution Layer Block Number">Block</th>
+              <th>Status</th>
+              <th data-timecol="duration">Time</th>
+              <th>Distance</th>
+            </tr>
+          </thead>
+          
+            <tbody>
+              <tr style="height: 430px;">
+                <td></td>
+                <td style="vertical-align: middle;" colspan="4">
+                  <div class="img-fluid mx-auto p-3 d-flex align-items-center" style="max-height: 400px; width: auto; overflow: hidden;">
+                    {{ template "timeline_svg" }}
+                  </div>
+                </td>
+                <td></td>
+              </tr>
+            </tbody>
+            
+        </table>
+      </div>
+    </div>
+  </div>
+{{ end }}

--- a/templates/validator/recentBlocks.html
+++ b/templates/validator/recentBlocks.html
@@ -1,0 +1,67 @@
+{{ define "recentBlocks" }}
+  <div class="card">
+    <div class="card-header">
+      <h4 class="card-title d-flex justify-content-between align-items-center" style="margin: .5rem 0;">
+        <span><i class="fa fa-cubes"></i> Most recent blocks</span>
+      </h4>
+    </div>
+    <div class="card-body p-0">
+      <div class="table-responsive">
+        <table class="table table-nobr" id="recent-blocks">
+          <thead>
+            <tr>
+              <th>Epoch</th>
+              <th>Slot</th>
+              <th data-toggle="tooltip" title="Execution Layer Block Number">Block</th>
+              <th>Status</th>
+              <th data-timecol="duration">Time</th>
+              <th>Graffiti</th>
+            </tr>
+          </thead>
+          {{ if gt .RecentBlockCount 0 }}
+            <tbody>
+              {{ range $i, $block := .RecentBlocks }}
+                <tr>
+                  <td><a href="/epoch/{{ $block.Epoch }}">{{ formatAddCommas $block.Epoch }}</a></td>
+                  {{ if eq .Status 2 }}
+                  <td><a href="/slot/{{ $block.BlockRoot }}">{{ formatAddCommas $block.Slot }}</a></td>
+                  {{ else }}
+                    <td><a href="/slot/{{ $block.Slot }}">{{ formatAddCommas $block.Slot }}</a></td>
+                  {{ end }}
+                  <td>{{ ethBlockLink $block.EthBlock }}</td>
+                  <td>
+                    {{ if eq $block.Slot 0 }}
+                      <span class="badge rounded-pill text-bg-info">Genesis</span>
+                    {{ else if eq .Status 0 }}
+                      <span class="badge rounded-pill text-bg-warning">Missed</span>
+                    {{ else if eq .Status 1 }}
+                      <span class="badge rounded-pill text-bg-success">Proposed</span>
+                    {{ else if eq .Status 2 }}
+                      <span class="badge rounded-pill text-bg-info">Missed (Orphaned)</span>
+                    {{ else }}
+                      <span class="badge rounded-pill text-bg-dark">Unknown</span>
+                    {{ end }}
+                  </td>
+                  <td data-timer="{{ $block.Ts.Unix }}"><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $block.Ts }}">{{ formatRecentTimeShort $block.Ts }}</span></td>
+                  <td>{{ formatGraffiti $block.Graffiti }}</td>
+                </tr>
+              {{ end }}
+            </tbody>
+          {{ else }}
+            <tbody>
+              <tr style="height: 430px;">
+                <td></td>
+                <td style="vertical-align: middle;" colspan="4">
+                  <div class="img-fluid mx-auto p-3 d-flex align-items-center" style="max-height: 400px; max-width: 400px; overflow: hidden;">
+                    {{ template "timeline_svg" }}
+                  </div>
+                </td>
+                <td></td>
+              </tr>
+            </tbody>
+          {{ end }}
+        </table>
+      </div>
+    </div>
+  </div>
+{{ end }}

--- a/templates/validator/validator.html
+++ b/templates/validator/validator.html
@@ -1,7 +1,7 @@
 {{ define "page" }}
   <div class="container mt-2">
     <div class="d-md-flex py-2 justify-content-md-between">
-      <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-table mx-2"></i> Validator xy</h1>
+      <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-table mx-2"></i> Validator {{ formatValidatorWithIndex .Index .Name }}</h1>
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb font-size-1 mb-0" style="padding:0; background-color:transparent;">
           <li class="breadcrumb-item"><a href="/" title="Home">Home</a></li>
@@ -12,16 +12,159 @@
     </div>
 
     <div class="card mt-2">
-      <div id="header-placeholder" style="height:45px;"></div>
       <div class="card-body px-0 py-3">
-        
+
+        <div class="row border-bottom p-2 mx-0">
+          <div class="col-md-2 d-flex" style="flex-direction: column; justify-content: flex-end;">
+            <span data-bs-toggle="tooltip" data-bs-placement="top" title="Validator Lifecycle Status">Status:</span>
+          </div>
+          <div class="col-md-10">
+            <!-- Validator lifecycle -->
+            <div class="validator__lifecycle-container">
+              <div class="validator__lifecycle-content">
+                <div id="lifecycle-deposited" class="validator__lifecycle-node-container validator__lifecycle-deposited {{ if .ShowEligible }}done{{ else }}active{{ end }}">
+                  <div class="validator__lifecycle-node-header">Deposited</div>
+                  <div class="validator__lifecycle-node" data-bs-toggle="tooltip" title="This will turn green when your deposit has been processed by the beacon chain">
+                    <i class="fas fa-check deposit-success"></i>
+                    <i class="fas fa-times fail deposit-fail"></i>
+                    <div class="spinner">
+                      <div class="double-bounce1"></div>
+                      <div class="double-bounce2"></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="validator__lifecycle-progress validator__lifecycle-deposited text-white">
+                  <div class="validator__lifecycle-progress-epoch">
+                    {{ if .ShowEligible }}
+                    <div data-bs-toggle="tooltip" title="The eligible epoch is when your validator is registered by the beacon chain and joins the queue to be activated.">
+                      <a href="/epoch/{{ .EligibleEpoch }}">{{ if eq .EligibleEpoch 0 }}genesis{{ else }}{{ .EligibleEpoch }}{{ end }}</a>
+                    </div>
+                    {{ end }}
+                  </div>
+                </div>
+                <div id="lifecycle-pending" class="validator__lifecycle-node-container validator__lifecycle-pending {{ if .ShowActivation }}{{ if ge .CurrentEpoch .ActivationEpoch }}done{{ else }}active{{ end }}{{ end }}">
+                  <div class="validator__lifecycle-node-container">
+                    <div class="validator__lifecycle-node-header">Pending</div>
+                    <div class="validator__lifecycle-node" data-bs-toggle="tooltip" title="After being processed your validator joins a queue to be activated">
+                      <i class="fas fa-hourglass-half pending-waiting"></i>
+                      <i class="fas fa-check"></i>
+                      <div class="spinner">
+                        <div class="double-bounce1"></div>
+                        <div class="double-bounce2"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="validator__lifecycle-progress validator__lifecycle-pending">
+                  <div class="validator__lifecycle-progress-epoch">
+                    {{ if .ShowActivation }}
+                      <div data-bs-toggle="tooltip" title="The activation epoch is when your validator becomes active.">
+                        <a href="/epoch/{{ .ActivationEpoch }}">{{ if eq .ActivationEpoch 0 }}genesis{{ else }}{{ .ActivationEpoch }}{{ end }}</a>
+                      </div>
+                    {{ end }}
+                  </div>
+                </div>
+                <div id="lifecycle-active" class="validator__lifecycle-node-container validator__lifecycle-active {{ if .IsActive }}{{ if gt .UpcheckActivity 0 }}online{{ else }}offline{{ end }}{{ else if .WasActive }}done{{ end }}">
+                  <div class="validator__lifecycle-node-container">
+                    <div class="validator__lifecycle-node-header">Active</div>
+                    <div class="validator__lifecycle-node" data-bs-toggle="tooltip" title="Once your validator reaches this state it can participate in attesting and proposing. Make sure it stays online!">
+                      <i class="fas fa-power-off online"></i>
+                      <i class="fas fa-power-off offline"></i>
+                      <i class="fas fa-check"></i>
+                      <div class="spinner">
+                        <div class="double-bounce1"></div>
+                        <div class="double-bounce2"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="validator__lifecycle-progress validator__lifecycle-active">
+                  <div class="validator__lifecycle-progress-epoch">
+                    {{ if .ShowExit }}
+                      <div data-bs-toggle="tooltip" title="The exit epoch is when your validator will leave the network">
+                        <a href="/epoch/{{ .ExitEpoch }}">{{ .ExitEpoch }}</a>
+                      </div>
+                    {{ end }}
+                  </div>
+                </div>
+                <div id="lifecycle-exited" class="validator__lifecycle-node-container validator__lifecycle-exited {{ if .ShowExit }}{{ if ge .CurrentEpoch .ExitEpoch }}done{{ else }}active{{ end }}{{ end }}">
+                  <div class="validator__lifecycle-node-container">
+                    <div class="validator__lifecycle-node-header">Exited</div>
+                    <div class="validator__lifecycle-node" data-bs-toggle="tooltip" title="If your validator misbehaves or chooses to leave the network it will join a queue to leave.">
+                      <i class="fas fa-door-open"></i>
+                      <div class="spinner">
+                        <div class="double-bounce1"></div>
+                        <div class="double-bounce2"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="row border-bottom p-2 mx-0">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Represents the index for this validator in the beacon chain">Index:</span></div>
+          <div class="col-md-10">
+            {{ formatValidatorWithIndex .Index .Name }}
+            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ .Index }}"></i>
+          </div>
+        </div>
+        <div class="row border-bottom p-2 mx-0">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Represents the public key for this validator">Public Key:</span></div>
+          <div class="col-md-10">
+            0x{{ printf "%x" .PublicKey }}
+            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ printf "%x" .PublicKey }}"></i>
+          </div>
+        </div>
+        <div class="row border-bottom p-2 mx-0">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="The current status for this validator">Status:</span></div>
+          <div class="col-md-10">
+            {{ .BeaconState }}
+          </div>
+        </div>
+        <div class="row border-bottom p-2 mx-0">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Represents the full balance for this validator (Epoch {{ .CurrentEpoch }})">Balance:</span></div>
+          <div class="col-md-10">
+            {{ formatEthFromGwei .Balance }}
+            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ formatEthFromGwei .Balance }}"></i>
+          </div>
+        </div>
+        <div class="row border-bottom p-2 mx-0">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Represents the full balance for this validator (Epoch {{ .CurrentEpoch }})">Effective Balance:</span></div>
+          <div class="col-md-10">
+            {{ formatEthAddCommasFromGwei .EffectiveBalance }} ETH
+          </div>
+        </div>
+        <div class="row border-bottom p-2 mx-0">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Represents the current withdrawal credentials for this validator">W/Credentials:</span></div>
+          <div class="col-md-10">
+            0x{{ printf "%x" .WithdrawCredentials }}
+            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ printf "%x" .WithdrawCredentials }}"></i>
+          </div>
+        </div>
+        {{ if .ShowWithdrawAddress }}
+        <div class="row border-bottom p-2 mx-0">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Represents the current withdrawal credentials for this validator">W/Address:</span></div>
+          <div class="col-md-10">
+            {{ ethAddressLink .WithdrawAddress }}
+          </div>
+        </div>
+        {{ end }}
         
       </div>
-      <div id="footer-placeholder" style="height:71px;"></div>
+    </div>
+
+    <div class="row">
+      <div class="mt-3 pr-lg-2"><!-- col-lg-6 -->
+        {{ template "recentBlocks" . }}
+      </div>
     </div>
   </div>
 {{ end }}
 {{ define "js" }}
 {{ end }}
 {{ define "css" }}
+  <link rel="stylesheet" href="/css/validator.css" />
 {{ end }}

--- a/templates/validator/validator.html
+++ b/templates/validator/validator.html
@@ -1,0 +1,27 @@
+{{ define "page" }}
+  <div class="container mt-2">
+    <div class="d-md-flex py-2 justify-content-md-between">
+      <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-table mx-2"></i> Validator xy</h1>
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb font-size-1 mb-0" style="padding:0; background-color:transparent;">
+          <li class="breadcrumb-item"><a href="/" title="Home">Home</a></li>
+          <li class="breadcrumb-item"><a href="/validators" title="Validators">Validators</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Validator details</li>
+        </ol>
+      </nav>
+    </div>
+
+    <div class="card mt-2">
+      <div id="header-placeholder" style="height:45px;"></div>
+      <div class="card-body px-0 py-3">
+        
+        
+      </div>
+      <div id="footer-placeholder" style="height:71px;"></div>
+    </div>
+  </div>
+{{ end }}
+{{ define "js" }}
+{{ end }}
+{{ define "css" }}
+{{ end }}

--- a/templates/validators/validators.html
+++ b/templates/validators/validators.html
@@ -70,12 +70,12 @@
                     <td>
                       {{- $validator.State -}}
                       {{- if $validator.ShowUpcheck }}
-                        {{- if eq $validator.UpcheckState 2 }}
-                          <i class="fas fa-power-off fa-sm text-success"></i>
-                        {{- else if eq $validator.UpcheckState 1 }}
-                          <i class="fas fa-power-off fa-sm text-warning"></i>
+                        {{- if eq $validator.UpcheckActivity $validator.UpcheckMaximum }}
+                          <i class="fas fa-power-off fa-sm text-success" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.UpcheckActivity }}/{{ $validator.UpcheckMaximum }}"></i>
+                        {{- else if gt $validator.UpcheckActivity 0 }}
+                          <i class="fas fa-power-off fa-sm text-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.UpcheckActivity }}/{{ $validator.UpcheckMaximum }}"></i>
                         {{- else -}}
-                          <i class="fas fa-power-off fa-sm text-danger"></i>
+                          <i class="fas fa-power-off fa-sm text-danger" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.UpcheckActivity }}/{{ $validator.UpcheckMaximum }}"></i>
                         {{- end -}}
                       {{- end -}}
                     </td>

--- a/templates/validators/validators.html
+++ b/templates/validators/validators.html
@@ -69,12 +69,12 @@
                     <td>{{ formatEthFromGwei $validator.Balance }} ({{ formatEthAddCommasFromGwei $validator.EffectiveBalance }} ETH)</td>
                     <td>
                       {{- $validator.State -}}
-                      {{- if $validator.ShowUpcheck }}
+                      {{- if $validator.ShowUpcheck -}}
                         {{- if eq $validator.UpcheckActivity $validator.UpcheckMaximum }}
                           <i class="fas fa-power-off fa-sm text-success" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.UpcheckActivity }}/{{ $validator.UpcheckMaximum }}"></i>
                         {{- else if gt $validator.UpcheckActivity 0 }}
                           <i class="fas fa-power-off fa-sm text-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.UpcheckActivity }}/{{ $validator.UpcheckMaximum }}"></i>
-                        {{- else -}}
+                        {{- else }}
                           <i class="fas fa-power-off fa-sm text-danger" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.UpcheckActivity }}/{{ $validator.UpcheckMaximum }}"></i>
                         {{- end -}}
                       {{- end -}}

--- a/templates/validators/validators.html
+++ b/templates/validators/validators.html
@@ -1,0 +1,155 @@
+{{ define "page" }}
+  <div class="container mt-2">
+    <div class="d-md-flex py-2 justify-content-md-between">
+      <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-table mx-2"></i> Validators Overview</h1>
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb font-size-1 mb-0" style="padding:0; background-color:transparent;">
+          <li class="breadcrumb-item"><a href="/" title="Home">Home</a></li>
+          <li class="breadcrumb-item"><a href="/validators" title="Validators">Validators</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Overview</li>
+        </ol>
+      </nav>
+    </div>
+
+    <div class="card mt-2">
+      <div id="header-placeholder" style="height:45px;"></div>
+      <div class="card-body px-0 py-3">
+        <div class="row">
+          <div class="col-sm-12 col-md-6 table-pagesize">
+            <form action="/validators" method="get">
+              <label class="px-2">
+                <span>Show </span>
+                <select name="c" aria-controls="validators" class="custom-select custom-select-sm form-control form-control-sm" onchange="this.form.submit()">
+                  <option value="{{ .PageSize }}" selected>{{ .PageSize }}</option>
+                  <option value="10">10</option>
+                  <option value="25">25</option>
+                  <option value="50">50</option>
+                  <option value="100">100</option>
+                </select>
+                {{ if not .IsDefaultPage }}
+                  <input name="s" type="hidden" value="{{ .CurrentPageIndex }}">
+                {{ end }}
+                {{ if .StateFilter }}
+                  <input name="q" type="hidden" value="{{ .StateFilter }}">
+                {{ end }}
+                <span> entries</span>
+              </label>
+            </form>
+          </div>
+          <div class="col-sm-12 col-md-6 table-search">
+            <div class="px-2" style="text-align: right;">
+              <form action="/validators" method="get">
+                <label>
+                  <input name="q" type="search" class="form-control form-control-sm" placeholder="Search by Pubkey / State" aria-controls="graffiti" value="{{ .StateFilter }}">
+                  <input name="c" type="hidden" value="{{ .PageSize }}">
+                </label>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div class="table-responsive px-0 py-1">
+          <table class="table table-nobr" id="validators">
+            <thead>
+              <tr>
+                <th>Index</th>
+                <th>Public Key</th>
+                <th>Balance</th>
+                <th>State</th>
+                <th>Activation</th>
+                <th>Exit</th>
+                <th>W/address</th>
+              </tr>
+            </thead>
+            {{ if gt .ValidatorCount 0 }}
+              <tbody>
+                {{ range $i, $validator := .Validators }}
+                  <tr>
+                    <td><a href="/validator/{{ $validator.Index }}">{{ formatValidatorWithIndex $validator.Index $validator.Name }}</a></td>
+                    <td><a href="/validator/0x{{ printf "%x" $validator.PublicKey }}" class="text-truncate d-inline-block" style="max-width: 200px">0x{{ printf "%x" $validator.PublicKey }}</a></td>
+                    <td>{{ formatEthFromGwei $validator.Balance }} ({{ formatEthAddCommasFromGwei $validator.EffectiveBalance }} ETH)</td>
+                    <td>
+                      {{- $validator.State -}}
+                      {{- if $validator.ShowUpcheck }}
+                        {{- if eq $validator.UpcheckState 2 }}
+                          <i class="fas fa-power-off fa-sm text-success"></i>
+                        {{- else if eq $validator.UpcheckState 1 }}
+                          <i class="fas fa-power-off fa-sm text-warning"></i>
+                        {{- else -}}
+                          <i class="fas fa-power-off fa-sm text-danger"></i>
+                        {{- end -}}
+                      {{- end -}}
+                    </td>
+                    <td>
+                      {{- if $validator.ShowActivation -}}
+                        <span data-timer="{{ $validator.ActivationTs.Unix }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.ActivationTs }}">{{ formatRecentTimeShort $validator.ActivationTs }}</span>
+                        (<a href="/epoch/{{ $validator.ActivationEpoch }}">Epoch {{ formatAddCommas $validator.ActivationEpoch }}</a>)
+                      {{- else -}}
+                        -
+                      {{- end -}}
+                    </td>
+                    <td>
+                      {{- if $validator.ShowExit -}}
+                        <span data-timer="{{ $validator.ExitTs.Unix }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.ExitTs }}">{{ formatRecentTimeShort $validator.ExitTs }}</span>
+                        (<a href="/epoch/{{ $validator.ExitEpoch }}">Epoch {{ formatAddCommas $validator.ExitEpoch }}</a>)
+                      {{- else -}}
+                        -
+                      {{- end -}}
+                    </td>
+                    <td>{{ ethAddressLink .WithdrawAddress }}</td>
+                  </tr>
+                {{ end }}
+              </tbody>
+            {{ else }}
+              <tbody>
+                <tr style="height: 430px;">
+                  <td class="d-none d-md-table-cell"></td>
+                  <td style="vertical-align: middle;" colspan="9">
+                    <div class="img-fluid mx-auto p-3 d-flex align-items-center" style="max-height: 400px; max-width: 400px; overflow: hidden;">
+                      {{ template "professor_svg" }}
+                    </div>
+                  </td>
+                  <td class="d-none d-md-table-cell"></td>
+                </tr>
+              </tbody>
+            {{ end }}
+          </table>
+        </div>
+        {{ if gt .TotalPages 1 }}
+          <div class="row">
+            <div class="col-sm-12 col-md-5 table-metainfo">
+              <div class="px-2">
+                <div class="table-meta" role="status" aria-live="polite">Showing validator {{ .FirstValidator }} to {{ .LastValidator }}</div>
+              </div>
+            </div>
+            <div class="col-sm-12 col-md-7 table-paging">
+              <div class="d-inline-block px-2">
+                <ul class="pagination">
+                  <li class="first paginate_button page-item {{ if le .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
+                    <a tab-index="1" aria-controls="tpg_first" class="page-link" href="/validators?{{ if .StateFilter }}q={{ .StateFilter }}&{{ end }}c={{ .PageSize }}">First</a>
+                  </li>
+                  <li class="previous paginate_button page-item {{ if eq .PrevPageIndex 0 }}disabled{{ end }}" id="tpg_previous">
+                    <a tab-index="1" aria-controls="tpg_previous" class="page-link" href="/validators?{{ if .StateFilter }}q={{ .StateFilter }}&{{ end }}s={{ .PrevPageValIdx }}&c={{ .PageSize }}"><i class="fas fa-chevron-left"></i></a>
+                  </li>
+                  <li class="page-item disabled">
+                    <a class="page-link" style="background-color: transparent;">{{ .CurrentPageIndex }} of {{ .TotalPages }}</a>
+                  </li>
+                  <li class="next paginate_button page-item {{ if eq .NextPageIndex 0 }}disabled{{ end }}" id="tpg_next">
+                    <a tab-index="1" aria-controls="tpg_next" class="page-link" href="/validators?{{ if .StateFilter }}q={{ .StateFilter }}&{{ end }}s={{ .NextPageValIdx }}&c={{ .PageSize }}"><i class="fas fa-chevron-right"></i></a>
+                  </li>
+                  <li class="last paginate_button page-item {{ if not (gt .LastPageValIdx .NextPageValIdx) }}disabled{{ end }}" id="tpg_last">
+                    <a tab-index="1" aria-controls="tpg_last" class="page-link" href="/validators?{{ if .StateFilter }}q={{ .StateFilter }}&{{ end }}s={{ .LastPageValIdx }}&c={{ .PageSize }}">Last</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        {{ end }}
+      </div>
+      <div id="footer-placeholder" style="height:71px;"></div>
+    </div>
+  </div>
+{{ end }}
+{{ define "js" }}
+{{ end }}
+{{ define "css" }}
+{{ end }}

--- a/types/models/validator.go
+++ b/types/models/validator.go
@@ -6,20 +6,41 @@ import (
 
 // ValidatorPageData is a struct to hold info for the validator page
 type ValidatorPageData struct {
+	CurrentEpoch        uint64    `json:"current_epoch"`
 	Index               uint64    `json:"index"`
 	Name                string    `json:"name"`
 	PublicKey           []byte    `json:"pubkey"`
 	Balance             uint64    `json:"balance"`
 	EffectiveBalance    uint64    `json:"eff_balance"`
 	State               string    `json:"state"`
-	ShowUpcheck         bool      `json:"show_upcheck"`
-	UpcheckState        uint8     `json:"upcheck_state"`
+	BeaconState         string    `json:"beacon_state"`
+	ShowEligible        bool      `json:"show_eligible"`
+	EligibleTs          time.Time `json:"eligible_ts"`
+	EligibleEpoch       uint64    `json:"eligible_epoch"`
 	ShowActivation      bool      `json:"show_activation"`
 	ActivationTs        time.Time `json:"activation_ts"`
 	ActivationEpoch     uint64    `json:"activation_epoch"`
+	IsActive            bool      `json:"is_active"`
+	WasActive           bool      `json:"was_active"`
+	UpcheckActivity     uint8     `json:"upcheck_act"`
+	UpcheckMaximum      uint8     `json:"upcheck_max"`
 	ShowExit            bool      `json:"show_exit"`
 	ExitTs              time.Time `json:"exit_ts"`
 	ExitEpoch           uint64    `json:"exit_epoch"`
+	WithdrawCredentials []byte    `json:"withdraw_credentials"`
 	ShowWithdrawAddress bool      `json:"show_withdraw_address"`
 	WithdrawAddress     []byte    `json:"withdraw_address"`
+
+	RecentBlocks     []*ValidatorPageDataBlocks `json:"recent_blocks"`
+	RecentBlockCount uint64                     `json:"recent_block_count"`
+}
+
+type ValidatorPageDataBlocks struct {
+	Epoch     uint64    `json:"epoch"`
+	Slot      uint64    `json:"slot"`
+	EthBlock  uint64    `json:"eth_block"`
+	Ts        time.Time `json:"ts"`
+	Status    uint64    `json:"status"`
+	BlockRoot string    `json:"block_root"`
+	Graffiti  []byte    `json:"graffiti"`
 }

--- a/types/models/validator.go
+++ b/types/models/validator.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"time"
+)
+
+// ValidatorPageData is a struct to hold info for the validator page
+type ValidatorPageData struct {
+	Index               uint64    `json:"index"`
+	Name                string    `json:"name"`
+	PublicKey           []byte    `json:"pubkey"`
+	Balance             uint64    `json:"balance"`
+	EffectiveBalance    uint64    `json:"eff_balance"`
+	State               string    `json:"state"`
+	ShowUpcheck         bool      `json:"show_upcheck"`
+	UpcheckState        uint8     `json:"upcheck_state"`
+	ShowActivation      bool      `json:"show_activation"`
+	ActivationTs        time.Time `json:"activation_ts"`
+	ActivationEpoch     uint64    `json:"activation_epoch"`
+	ShowExit            bool      `json:"show_exit"`
+	ExitTs              time.Time `json:"exit_ts"`
+	ExitEpoch           uint64    `json:"exit_epoch"`
+	ShowWithdrawAddress bool      `json:"show_withdraw_address"`
+	WithdrawAddress     []byte    `json:"withdraw_address"`
+}

--- a/types/models/validators.go
+++ b/types/models/validators.go
@@ -32,7 +32,8 @@ type ValidatorsPageDataValidator struct {
 	EffectiveBalance    uint64    `json:"eff_balance"`
 	State               string    `json:"state"`
 	ShowUpcheck         bool      `json:"show_upcheck"`
-	UpcheckState        uint8     `json:"upcheck_state"`
+	UpcheckActivity     uint8     `json:"upcheck_act"`
+	UpcheckMaximum      uint8     `json:"upcheck_max"`
 	ShowActivation      bool      `json:"show_activation"`
 	ActivationTs        time.Time `json:"activation_ts"`
 	ActivationEpoch     uint64    `json:"activation_epoch"`

--- a/types/models/validators.go
+++ b/types/models/validators.go
@@ -1,0 +1,44 @@
+package models
+
+import (
+	"time"
+)
+
+// ValidatorsPageData is a struct to hold info for the validators page
+type ValidatorsPageData struct {
+	Validators     []*ValidatorsPageDataValidator `json:"validators"`
+	ValidatorCount uint64                         `json:"validator_count"`
+	FirstValidator uint64                         `json:"first_validx"`
+	LastValidator  uint64                         `json:"last_validx"`
+	StateFilter    string                         `json:"state_filter"`
+
+	IsDefaultPage     bool   `json:"default_page"`
+	TotalPages        uint64 `json:"total_pages"`
+	PageSize          uint64 `json:"page_size"`
+	CurrentPageIndex  uint64 `json:"page_index"`
+	CurrentPageValIdx uint64 `json:"page_validx"`
+	PrevPageIndex     uint64 `json:"prev_page_index"`
+	PrevPageValIdx    uint64 `json:"prev_page_validx"`
+	NextPageIndex     uint64 `json:"next_page_index"`
+	NextPageValIdx    uint64 `json:"next_page_validx"`
+	LastPageValIdx    uint64 `json:"last_page_validx"`
+}
+
+type ValidatorsPageDataValidator struct {
+	Index               uint64    `json:"index"`
+	Name                string    `json:"name"`
+	PublicKey           []byte    `json:"pubkey"`
+	Balance             uint64    `json:"balance"`
+	EffectiveBalance    uint64    `json:"eff_balance"`
+	State               string    `json:"state"`
+	ShowUpcheck         bool      `json:"show_upcheck"`
+	UpcheckState        uint8     `json:"upcheck_state"`
+	ShowActivation      bool      `json:"show_activation"`
+	ActivationTs        time.Time `json:"activation_ts"`
+	ActivationEpoch     uint64    `json:"activation_epoch"`
+	ShowExit            bool      `json:"show_exit"`
+	ExitTs              time.Time `json:"exit_ts"`
+	ExitEpoch           uint64    `json:"exit_epoch"`
+	ShowWithdrawAddress bool      `json:"show_withdraw_address"`
+	WithdrawAddress     []byte    `json:"withdraw_address"`
+}

--- a/utils/format.go
+++ b/utils/format.go
@@ -300,9 +300,9 @@ func FormatSlashedValidator(index uint64, name string) template.HTML {
 
 func formatValidator(index uint64, name string, icon string) template.HTML {
 	if name != "" {
-		return template.HTML(fmt.Sprintf("<span class=\"validator-label validator-name\" data-bs-toggle=\"tooltip\" data-bs-placement=\"top\" data-bs-title=\"%v\"><i class=\"fas %v\"></i> %v</span>", index, icon, html.EscapeString(name)))
+		return template.HTML(fmt.Sprintf("<span class=\"validator-label validator-name\" data-bs-toggle=\"tooltip\" data-bs-placement=\"top\" data-bs-title=\"%v\"><i class=\"fas %v\"></i> <a href=\"/validator/%v\">%v</a></span>", index, icon, index, html.EscapeString(name)))
 	}
-	return template.HTML(fmt.Sprintf("<span class=\"validator-label validator-index\"><i class=\"fas %v\"></i> %v</span>", icon, index))
+	return template.HTML(fmt.Sprintf("<span class=\"validator-label validator-index\"><i class=\"fas %v\"></i> <a href=\"/validator/%v\">%v</a></span>", icon, index, index))
 }
 
 func FormatValidatorWithIndex(index uint64, name string) template.HTML {

--- a/utils/format.go
+++ b/utils/format.go
@@ -305,6 +305,13 @@ func formatValidator(index uint64, name string, icon string) template.HTML {
 	return template.HTML(fmt.Sprintf("<span class=\"validator-label validator-index\"><i class=\"fas %v\"></i> %v</span>", icon, index))
 }
 
+func FormatValidatorWithIndex(index uint64, name string) template.HTML {
+	if name != "" {
+		return template.HTML(fmt.Sprintf("<span class=\"validator-label validator-name\">%v (%v)</span>", html.EscapeString(name), index))
+	}
+	return template.HTML(fmt.Sprintf("<span class=\"validator-label validator-index\">%v</span>", index))
+}
+
 func FormatRecentTimeShort(ts time.Time) template.HTML {
 	duration := ts.Sub(time.Now())
 	var timeStr string

--- a/utils/templateFucs.go
+++ b/utils/templateFucs.go
@@ -49,6 +49,7 @@ func GetTemplateFuncs() template.FuncMap {
 		"ethBlockHashLink":           FormatEthBlockHashLink,
 		"ethAddressLink":             FormatEthAddressLink,
 		"formatValidator":            FormatValidator,
+		"formatValidatorWithIndex":   FormatValidatorWithIndex,
 		"formatSlashedValidator":     FormatSlashedValidator,
 		"formatRecentTimeShort":      FormatRecentTimeShort,
 		"formatGraffiti":             FormatGraffiti,


### PR DESCRIPTION
This adds a validator overview (`/validators`) and a validator details page (`/validator/{indexOrPubKey}`).
No additional RPC calls are required as the most recent validator set is already cached in memory by the indexer.

#### Validator Overview
* List view for most recent validator set.
* Show online status by checking aggregations from last 3 epochs (from memory only)

#### Validator Details
* Validator lifecycle & status
* Basic properties (Index, PubKey, Balance, EffectiveBalance, WithdrawalCredentials)
* List of last assigned slots (showing missed & orphaned slots as well)