### PR TITLE
Added filtered slots page (`/slots/filtered`)

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -72,6 +72,7 @@ func startFrontend() {
 	router.HandleFunc("/epochs", handlers.Epochs).Methods("GET")
 	router.HandleFunc("/epoch/{epoch}", handlers.Epoch).Methods("GET")
 	router.HandleFunc("/slots", handlers.Slots).Methods("GET")
+	router.HandleFunc("/slots/filtered", handlers.SlotsFiltered).Methods("GET")
 	router.HandleFunc("/slot/{slotOrHash}", handlers.Slot).Methods("GET")
 	router.HandleFunc("/slot/{hash}/blob/{blobIdx}", handlers.SlotBlob).Methods("GET")
 	router.HandleFunc("/search", handlers.Search).Methods("GET")

--- a/db/schema/pgsql/20230902172124_validator-names.sql
+++ b/db/schema/pgsql/20230902172124_validator-names.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE IF NOT EXISTS public."validator_names"
+(
+    "index" bigint NOT NULL,
+    "name" character varying(250) NOT NULL,
+    PRIMARY KEY ("index")
+);
+
+CREATE INDEX IF NOT EXISTS "validator_names_name_idx"
+    ON public."validator_names" USING gin 
+    ("name" gin_trgm_ops);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/db/schema/sqlite/20230902172124_validator-names.sql
+++ b/db/schema/sqlite/20230902172124_validator-names.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE IF NOT EXISTS "validator_names"
+(
+    "index" bigint NOT NULL,
+    "name" character varying(250) NOT NULL,
+    PRIMARY KEY ("index")
+);
+
+CREATE INDEX IF NOT EXISTS "validator_names_name_idx"
+    ON "validator_names" 
+    ("name" ASC);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/dbtypes/dbtypes.go
+++ b/dbtypes/dbtypes.go
@@ -5,6 +5,11 @@ type ExplorerState struct {
 	Value string `db:"value"`
 }
 
+type ValidatorName struct {
+	Index uint64 `db:"index"`
+	Name  string `db:"name"`
+}
+
 type Block struct {
 	Root                  []byte  `db:"root"`
 	Slot                  uint64  `db:"slot"`

--- a/dbtypes/dbtypes.go
+++ b/dbtypes/dbtypes.go
@@ -15,7 +15,7 @@ type Block struct {
 	Slot                  uint64  `db:"slot"`
 	ParentRoot            []byte  `db:"parent_root"`
 	StateRoot             []byte  `db:"state_root"`
-	Orphaned              bool    `db:"orphaned"`
+	Orphaned              uint8   `db:"orphaned"`
 	Proposer              uint64  `db:"proposer"`
 	Graffiti              []byte  `db:"graffiti"`
 	GraffitiText          string  `db:"graffiti_text"`

--- a/dbtypes/other.go
+++ b/dbtypes/other.go
@@ -5,3 +5,11 @@ type AssignedBlock struct {
 	Proposer uint64 `db:"proposer"`
 	Block    *Block `db:"block"`
 }
+
+type BlockFilter struct {
+	Graffiti      string
+	ProposerIndex *uint64
+	ProposerName  string
+	WithOrphaned  bool
+	WithMissing   bool
+}

--- a/dbtypes/other.go
+++ b/dbtypes/other.go
@@ -10,6 +10,6 @@ type BlockFilter struct {
 	Graffiti      string
 	ProposerIndex *uint64
 	ProposerName  string
-	WithOrphaned  bool
-	WithMissing   bool
+	WithOrphaned  uint8
+	WithMissing   uint8
 }

--- a/handlers/epoch.go
+++ b/handlers/epoch.go
@@ -132,7 +132,7 @@ func buildEpochPageData(epoch uint64) (*models.EpochPageData, time.Duration) {
 			dbSlot := dbSlots[dbIdx]
 			dbIdx++
 			blockStatus := uint8(1)
-			if dbSlot.Orphaned {
+			if dbSlot.Orphaned == 1 {
 				blockStatus = 2
 				pageData.OrphanedCount++
 			} else {

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -208,7 +208,7 @@ func buildIndexPageRecentBlocksData(pageData *models.IndexPageData, currentSlot 
 			continue
 		}
 		blockStatus := 1
-		if blockData.Orphaned {
+		if blockData.Orphaned == 1 {
 			blockStatus = 2
 		}
 		pageData.RecentBlocks = append(pageData.RecentBlocks, &models.IndexPageDataBlocks{
@@ -253,7 +253,7 @@ func buildIndexPageRecentSlotsData(pageData *models.IndexPageData, firstSlot uin
 			dbSlot := dbSlots[dbIdx]
 			dbIdx++
 			blockStatus := uint64(1)
-			if dbSlot.Orphaned {
+			if dbSlot.Orphaned == 1 {
 				blockStatus = 2
 			}
 

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -85,7 +85,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			LIMIT 1`,
 	}), "%"+searchQuery+"%")
 	if err == nil {
-		http.Redirect(w, r, "/slots?q="+searchQuery, http.StatusMovedPermanently)
+		http.Redirect(w, r, "/filtered?f.graffiti="+searchQuery, http.StatusMovedPermanently)
 		return
 	}
 

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -85,7 +85,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 			LIMIT 1`,
 	}), "%"+searchQuery+"%")
 	if err == nil {
-		http.Redirect(w, r, "/filtered?f.graffiti="+searchQuery, http.StatusMovedPermanently)
+		http.Redirect(w, r, "/filtered?f&f.graffiti="+searchQuery, http.StatusMovedPermanently)
 		return
 	}
 

--- a/handlers/slots.go
+++ b/handlers/slots.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/pk910/light-beaconchain-explorer/dbtypes"
 	"github.com/pk910/light-beaconchain-explorer/services"
 	"github.com/pk910/light-beaconchain-explorer/templates"
 	"github.com/pk910/light-beaconchain-explorer/types/models"
@@ -370,7 +371,10 @@ func buildSlotsPageDataWithGraffitiFilter(graffiti string, pageIdx uint64, pageS
 
 	// load slots
 	pageData.Slots = make([]*models.SlotsPageDataSlot, 0)
-	dbBlocks := services.GlobalBeaconService.GetDbBlocksByGraffiti(graffiti, pageIdx, uint32(pageSize), true)
+	dbBlocks := services.GlobalBeaconService.GetDbBlocksByFilter(&dbtypes.BlockFilter{
+		Graffiti:     graffiti,
+		WithOrphaned: true,
+	}, pageIdx, uint32(pageSize))
 	haveMore := false
 	for idx, dbBlock := range dbBlocks {
 		if idx >= int(pageSize) {
@@ -379,7 +383,7 @@ func buildSlotsPageDataWithGraffitiFilter(graffiti string, pageIdx uint64, pageS
 		}
 		slot := dbBlock.Slot
 		blockStatus := uint8(1)
-		if dbBlock.Orphaned {
+		if dbBlock.Block.Orphaned {
 			blockStatus = 2
 		}
 
@@ -392,16 +396,16 @@ func buildSlotsPageDataWithGraffitiFilter(graffiti string, pageIdx uint64, pageS
 			Synchronized:          true,
 			Proposer:              dbBlock.Proposer,
 			ProposerName:          services.GlobalBeaconService.GetValidatorName(dbBlock.Proposer),
-			AttestationCount:      dbBlock.AttestationCount,
-			DepositCount:          dbBlock.DepositCount,
-			ExitCount:             dbBlock.ExitCount,
-			ProposerSlashingCount: dbBlock.ProposerSlashingCount,
-			AttesterSlashingCount: dbBlock.AttesterSlashingCount,
-			SyncParticipation:     float64(dbBlock.SyncParticipation) * 100,
-			EthTransactionCount:   dbBlock.EthTransactionCount,
-			EthBlockNumber:        dbBlock.EthBlockNumber,
-			Graffiti:              dbBlock.Graffiti,
-			BlockRoot:             dbBlock.Root,
+			AttestationCount:      dbBlock.Block.AttestationCount,
+			DepositCount:          dbBlock.Block.DepositCount,
+			ExitCount:             dbBlock.Block.ExitCount,
+			ProposerSlashingCount: dbBlock.Block.ProposerSlashingCount,
+			AttesterSlashingCount: dbBlock.Block.AttesterSlashingCount,
+			SyncParticipation:     float64(dbBlock.Block.SyncParticipation) * 100,
+			EthTransactionCount:   dbBlock.Block.EthTransactionCount,
+			EthBlockNumber:        dbBlock.Block.EthBlockNumber,
+			Graffiti:              dbBlock.Block.Graffiti,
+			BlockRoot:             dbBlock.Block.Root,
 		}
 		pageData.Slots = append(pageData.Slots, slotData)
 

--- a/handlers/slots_filtered.go
+++ b/handlers/slots_filtered.go
@@ -1,0 +1,190 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/pk910/light-beaconchain-explorer/dbtypes"
+	"github.com/pk910/light-beaconchain-explorer/services"
+	"github.com/pk910/light-beaconchain-explorer/templates"
+	"github.com/pk910/light-beaconchain-explorer/types/models"
+	"github.com/pk910/light-beaconchain-explorer/utils"
+	"github.com/sirupsen/logrus"
+)
+
+// SlotsFiltered will return the filtered "slots" page using a go template
+func SlotsFiltered(w http.ResponseWriter, r *http.Request) {
+	var slotsTemplateFiles = append(layoutTemplateFiles,
+		"slots_filtered/slots_filtered.html",
+		"_svg/professor.html",
+	)
+
+	var pageTemplate = templates.GetTemplate(slotsTemplateFiles...)
+
+	w.Header().Set("Content-Type", "text/html")
+	data := InitPageData(w, r, "blockchain", "/slots/filtered", "Filtered Slots", slotsTemplateFiles)
+
+	urlArgs := r.URL.Query()
+	var pageSize uint64 = 50
+	if urlArgs.Has("c") {
+		pageSize, _ = strconv.ParseUint(urlArgs.Get("c"), 10, 64)
+	}
+	var pageIdx uint64 = 0
+	if urlArgs.Has("s") {
+		pageIdx, _ = strconv.ParseUint(urlArgs.Get("s"), 10, 64)
+	}
+
+	var graffiti string
+	if urlArgs.Has("f.graffiti") {
+		graffiti = urlArgs.Get("f.graffiti")
+	}
+	var proposer string
+	if urlArgs.Has("f.proposer") {
+		proposer = urlArgs.Get("f.proposer")
+	}
+	var pname string
+	if urlArgs.Has("f.pname") {
+		pname = urlArgs.Get("f.pname")
+	}
+	var withOrphaned uint64
+	if urlArgs.Has("f.orphaned") {
+		withOrphaned, _ = strconv.ParseUint(urlArgs.Get("f.orphaned"), 10, 64)
+	}
+	var withMissing uint64
+	if urlArgs.Has("f.missing") {
+		withMissing, _ = strconv.ParseUint(urlArgs.Get("f.missing"), 10, 64)
+	}
+	data.Data = getFilteredSlotsPageData(pageIdx, pageSize, graffiti, proposer, pname, uint8(withOrphaned), uint8(withMissing))
+
+	if handleTemplateError(w, r, "slots_filtered.go", "SlotsFiltered", "", pageTemplate.ExecuteTemplate(w, "layout", data)) != nil {
+		return // an error has occurred and was processed
+	}
+}
+
+func getFilteredSlotsPageData(pageIdx uint64, pageSize uint64, graffiti string, proposer string, pname string, withOrphaned uint8, withMissing uint8) *models.SlotsFilteredPageData {
+	pageData := &models.SlotsFilteredPageData{}
+	pageCacheKey := fmt.Sprintf("slots_filtered:%v:%v:%v:%v:%v:%v:%v", pageIdx, pageSize, graffiti, proposer, pname, withOrphaned, withMissing)
+	pageData = services.GlobalFrontendCache.ProcessCachedPage(pageCacheKey, true, pageData, func(_ *services.FrontendCacheProcessingPage) interface{} {
+		return buildFilteredSlotsPageData(pageIdx, pageSize, graffiti, proposer, pname, withOrphaned, withMissing)
+	}).(*models.SlotsFilteredPageData)
+	return pageData
+}
+
+func buildFilteredSlotsPageData(pageIdx uint64, pageSize uint64, graffiti string, proposer string, pname string, withOrphaned uint8, withMissing uint8) *models.SlotsFilteredPageData {
+	filterArgs := url.Values{}
+	if graffiti != "" {
+		filterArgs.Add("f.graffiti", graffiti)
+	}
+	if proposer != "" {
+		filterArgs.Add("f.proposer", proposer)
+	}
+	if pname != "" {
+		filterArgs.Add("f.pname", pname)
+	}
+	if withOrphaned != 0 {
+		filterArgs.Add("f.orphaned", fmt.Sprintf("%v", withOrphaned))
+	}
+	if withMissing != 0 {
+		filterArgs.Add("f.missing", fmt.Sprintf("%v", withMissing))
+	}
+
+	pageData := &models.SlotsFilteredPageData{
+		FilterGraffiti:     graffiti,
+		FilterProposer:     proposer,
+		FilterProposerName: pname,
+		FilterWithOrphaned: withOrphaned,
+		FilterWithMissing:  withMissing,
+	}
+	logrus.Printf("slots_filtered page called: %v:%v [%v]", pageIdx, pageSize, graffiti)
+	if pageIdx == 0 {
+		pageData.IsDefaultPage = true
+	}
+
+	if pageSize > 100 {
+		pageSize = 100
+	}
+	pageData.PageSize = pageSize
+	pageData.TotalPages = pageIdx + 1
+	pageData.CurrentPageIndex = pageIdx + 1
+	pageData.CurrentPageSlot = pageIdx
+	if pageIdx >= 1 {
+		pageData.PrevPageIndex = pageIdx
+		pageData.PrevPageSlot = pageIdx - 1
+	}
+	pageData.LastPageSlot = 0
+
+	finalizedEpoch, _ := services.GlobalBeaconService.GetFinalizedEpoch()
+	currentSlot := utils.TimeToSlot(uint64(time.Now().Unix()))
+
+	// load slots
+	pageData.Slots = make([]*models.SlotsFilteredPageDataSlot, 0)
+	blockFilter := &dbtypes.BlockFilter{
+		Graffiti:     graffiti,
+		ProposerName: pname,
+		WithOrphaned: withOrphaned,
+		WithMissing:  withMissing,
+	}
+	if proposer != "" {
+		pidx, _ := strconv.ParseUint(proposer, 10, 64)
+		blockFilter.ProposerIndex = &pidx
+	}
+
+	dbBlocks := services.GlobalBeaconService.GetDbBlocksByFilter(blockFilter, pageIdx, uint32(pageSize))
+	haveMore := false
+	for idx, dbBlock := range dbBlocks {
+		if idx >= int(pageSize) {
+			haveMore = true
+			break
+		}
+		slot := dbBlock.Slot
+
+		slotData := &models.SlotsFilteredPageDataSlot{
+			Slot:         slot,
+			Epoch:        utils.EpochOfSlot(slot),
+			Ts:           utils.SlotToTime(slot),
+			Finalized:    finalizedEpoch >= int64(utils.EpochOfSlot(slot)),
+			Synchronized: true,
+			Scheduled:    slot >= currentSlot,
+			Proposer:     dbBlock.Proposer,
+			ProposerName: services.GlobalBeaconService.GetValidatorName(dbBlock.Proposer),
+		}
+
+		if dbBlock.Block != nil {
+			slotData.Status = 1
+			if dbBlock.Block.Orphaned == 1 {
+				slotData.Status = 2
+			}
+			slotData.AttestationCount = dbBlock.Block.AttestationCount
+			slotData.DepositCount = dbBlock.Block.DepositCount
+			slotData.ExitCount = dbBlock.Block.ExitCount
+			slotData.ProposerSlashingCount = dbBlock.Block.ProposerSlashingCount
+			slotData.AttesterSlashingCount = dbBlock.Block.AttesterSlashingCount
+			slotData.SyncParticipation = float64(dbBlock.Block.SyncParticipation) * 100
+			slotData.EthTransactionCount = dbBlock.Block.EthTransactionCount
+			slotData.EthBlockNumber = dbBlock.Block.EthBlockNumber
+			slotData.Graffiti = dbBlock.Block.Graffiti
+			slotData.BlockRoot = dbBlock.Block.Root
+		}
+		pageData.Slots = append(pageData.Slots, slotData)
+	}
+	pageData.SlotCount = uint64(len(pageData.Slots))
+	if pageData.SlotCount > 0 {
+		pageData.FirstSlot = pageData.Slots[0].Slot
+		pageData.LastSlot = pageData.Slots[pageData.SlotCount-1].Slot
+	}
+	if haveMore {
+		pageData.NextPageIndex = pageIdx + 1
+		pageData.NextPageSlot = pageIdx + 1
+		pageData.TotalPages++
+	}
+
+	pageData.FirstPageLink = fmt.Sprintf("/slots/filtered?%v&c=%v", filterArgs.Encode(), pageData.PageSize)
+	pageData.PrevPageLink = fmt.Sprintf("/slots/filtered?%v&c=%v&s=%v", filterArgs.Encode(), pageData.PageSize, pageData.PrevPageSlot)
+	pageData.NextPageLink = fmt.Sprintf("/slots/filtered?%v&c=%v&s=%v", filterArgs.Encode(), pageData.PageSize, pageData.NextPageSlot)
+	pageData.LastPageLink = fmt.Sprintf("/slots/filtered?%v&c=%v&s=%v", filterArgs.Encode(), pageData.PageSize, pageData.LastPageSlot)
+
+	return pageData
+}

--- a/handlers/slots_filtered.go
+++ b/handlers/slots_filtered.go
@@ -38,24 +38,30 @@ func SlotsFiltered(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var graffiti string
-	if urlArgs.Has("f.graffiti") {
-		graffiti = urlArgs.Get("f.graffiti")
-	}
 	var proposer string
-	if urlArgs.Has("f.proposer") {
-		proposer = urlArgs.Get("f.proposer")
-	}
 	var pname string
-	if urlArgs.Has("f.pname") {
-		pname = urlArgs.Get("f.pname")
-	}
 	var withOrphaned uint64
-	if urlArgs.Has("f.orphaned") {
-		withOrphaned, _ = strconv.ParseUint(urlArgs.Get("f.orphaned"), 10, 64)
-	}
 	var withMissing uint64
-	if urlArgs.Has("f.missing") {
-		withMissing, _ = strconv.ParseUint(urlArgs.Get("f.missing"), 10, 64)
+
+	if urlArgs.Has("f") {
+		if urlArgs.Has("f.graffiti") {
+			graffiti = urlArgs.Get("f.graffiti")
+		}
+		if urlArgs.Has("f.proposer") {
+			proposer = urlArgs.Get("f.proposer")
+		}
+		if urlArgs.Has("f.pname") {
+			pname = urlArgs.Get("f.pname")
+		}
+		if urlArgs.Has("f.orphaned") {
+			withOrphaned, _ = strconv.ParseUint(urlArgs.Get("f.orphaned"), 10, 64)
+		}
+		if urlArgs.Has("f.missing") {
+			withMissing, _ = strconv.ParseUint(urlArgs.Get("f.missing"), 10, 64)
+		}
+	} else {
+		withOrphaned = 1
+		withMissing = 1
 	}
 	data.Data = getFilteredSlotsPageData(pageIdx, pageSize, graffiti, proposer, pname, uint8(withOrphaned), uint8(withMissing))
 

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
+	"github.com/pk910/light-beaconchain-explorer/dbtypes"
 	"github.com/pk910/light-beaconchain-explorer/rpctypes"
 	"github.com/pk910/light-beaconchain-explorer/services"
 	"github.com/pk910/light-beaconchain-explorer/templates"
@@ -149,7 +150,11 @@ func buildValidatorPageData(validatorIndex uint64) (*models.ValidatorPageData, t
 
 	// load latest blocks
 	pageData.RecentBlocks = make([]*models.ValidatorPageDataBlocks, 0)
-	blocksData := services.GlobalBeaconService.GetDbBlocksByProposer(validatorIndex, 0, 10, true, true)
+	blocksData := services.GlobalBeaconService.GetDbBlocksByFilter(&dbtypes.BlockFilter{
+		ProposerIndex: &validatorIndex,
+		WithOrphaned:  true,
+		WithMissing:   true,
+	}, 0, 10)
 	for _, blockData := range blocksData {
 		blockStatus := 1
 		if blockData.Block == nil {

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -152,14 +152,14 @@ func buildValidatorPageData(validatorIndex uint64) (*models.ValidatorPageData, t
 	pageData.RecentBlocks = make([]*models.ValidatorPageDataBlocks, 0)
 	blocksData := services.GlobalBeaconService.GetDbBlocksByFilter(&dbtypes.BlockFilter{
 		ProposerIndex: &validatorIndex,
-		WithOrphaned:  true,
-		WithMissing:   true,
+		WithOrphaned:  1,
+		WithMissing:   1,
 	}, 0, 10)
 	for _, blockData := range blocksData {
 		blockStatus := 1
 		if blockData.Block == nil {
 			blockStatus = 0
-		} else if blockData.Block.Orphaned {
+		} else if blockData.Block.Orphaned == 1 {
 			blockStatus = 2
 		}
 		blockEntry := models.ValidatorPageDataBlocks{

--- a/handlers/validator_slots.go
+++ b/handlers/validator_slots.go
@@ -91,8 +91,8 @@ func buildValidatorSlotsPageData(validator uint64, pageIdx uint64, pageSize uint
 	pageData.Slots = make([]*models.ValidatorSlotsPageDataSlot, 0)
 	dbBlocks := services.GlobalBeaconService.GetDbBlocksByFilter(&dbtypes.BlockFilter{
 		ProposerIndex: &validator,
-		WithOrphaned:  true,
-		WithMissing:   true,
+		WithOrphaned:  1,
+		WithMissing:   1,
 	}, pageIdx, uint32(pageSize))
 	haveMore := false
 	for idx, blockAssignment := range dbBlocks {
@@ -115,7 +115,7 @@ func buildValidatorSlotsPageData(validator uint64, pageIdx uint64, pageSize uint
 
 		if blockAssignment.Block != nil {
 			dbBlock := blockAssignment.Block
-			if dbBlock.Orphaned {
+			if dbBlock.Orphaned == 1 {
 				slotData.Status = 2
 			} else {
 				slotData.Status = 1

--- a/handlers/validator_slots.go
+++ b/handlers/validator_slots.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
+	"github.com/pk910/light-beaconchain-explorer/dbtypes"
 	"github.com/pk910/light-beaconchain-explorer/services"
 	"github.com/pk910/light-beaconchain-explorer/templates"
 	"github.com/pk910/light-beaconchain-explorer/types/models"
@@ -88,7 +89,11 @@ func buildValidatorSlotsPageData(validator uint64, pageIdx uint64, pageSize uint
 
 	// load slots
 	pageData.Slots = make([]*models.ValidatorSlotsPageDataSlot, 0)
-	dbBlocks := services.GlobalBeaconService.GetDbBlocksByProposer(validator, pageIdx, uint32(pageSize), true, true)
+	dbBlocks := services.GlobalBeaconService.GetDbBlocksByFilter(&dbtypes.BlockFilter{
+		ProposerIndex: &validator,
+		WithOrphaned:  true,
+		WithMissing:   true,
+	}, pageIdx, uint32(pageSize))
 	haveMore := false
 	for idx, blockAssignment := range dbBlocks {
 		if idx >= int(pageSize) {

--- a/indexer/cache_logic.go
+++ b/indexer/cache_logic.go
@@ -238,7 +238,7 @@ func (cache *indexerCache) processOrphanedBlocks(processedEpoch int64) error {
 			continue
 		}
 		dbBlock := buildDbBlock(block, cache.getEpochStats(utils.EpochOfSlot(block.Slot), nil))
-		dbBlock.Orphaned = true
+		dbBlock.Orphaned = 1
 		db.InsertBlock(dbBlock, tx)
 		db.InsertOrphanedBlock(block.buildOrphanedBlock(), tx)
 	}

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -101,7 +101,6 @@ func (client *IndexerClient) runIndexerClientLoop() {
 
 			genesisTime := time.Unix(int64(utils.Config.Chain.GenesisTimestamp), 0)
 			genesisSince := time.Since(genesisTime)
-			fmt.Printf("genesis %v\n", int(genesisSince.Seconds()))
 			if genesisSince < 0 {
 				if genesisSince > (time.Duration)(0-waitTime)*time.Second {
 					waitTime = int(genesisSince.Abs().Seconds())

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -485,6 +485,10 @@ func (indexer *Indexer) BuildLiveBlock(block *CacheBlock) *dbtypes.Block {
 		}
 		block.dbBlockCache = buildDbBlock(block, epochStats)
 	}
-	block.dbBlockCache.Orphaned = !block.IsCanonical(indexer, nil)
+	if block.IsCanonical(indexer, nil) {
+		block.dbBlockCache.Orphaned = 0
+	} else {
+		block.dbBlockCache.Orphaned = 1
+	}
 	return block.dbBlockCache
 }

--- a/services/beaconservice.go
+++ b/services/beaconservice.go
@@ -49,12 +49,7 @@ func StartBeaconService() error {
 	}
 
 	validatorNames := &ValidatorNames{}
-	if utils.Config.Frontend.ValidatorNamesYaml != "" {
-		validatorNames.LoadFromYaml(utils.Config.Frontend.ValidatorNamesYaml)
-	}
-	if utils.Config.Frontend.ValidatorNamesInventory != "" {
-		validatorNames.LoadFromRangesApi(utils.Config.Frontend.ValidatorNamesInventory)
-	}
+	validatorNames.LoadValidatorNames()
 
 	GlobalBeaconService = &BeaconService{
 		indexer:          indexer,

--- a/services/validatornames.go
+++ b/services/validatornames.go
@@ -11,17 +11,26 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pk910/light-beaconchain-explorer/db"
+	"github.com/pk910/light-beaconchain-explorer/dbtypes"
+	"github.com/pk910/light-beaconchain-explorer/utils"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
+var logger_vn = logrus.StandardLogger().WithField("module", "validator_names")
+
 type ValidatorNames struct {
-	namesMutex sync.RWMutex
-	names      map[uint64]string
+	loadingMutex sync.Mutex
+	loading      bool
+	namesMutex   sync.RWMutex
+	names        map[uint64]string
 }
 
 func (vn *ValidatorNames) GetValidatorName(index uint64) string {
-	vn.namesMutex.RLock()
+	if !vn.namesMutex.TryRLock() {
+		return ""
+	}
 	defer vn.namesMutex.RUnlock()
 	if vn.names == nil {
 		return ""
@@ -29,13 +38,43 @@ func (vn *ValidatorNames) GetValidatorName(index uint64) string {
 	return vn.names[index]
 }
 
-func (vn *ValidatorNames) LoadFromYaml(fileName string) error {
-	vn.namesMutex.Lock()
-	defer vn.namesMutex.Unlock()
+func (vn *ValidatorNames) LoadValidatorNames() {
+	vn.loadingMutex.Lock()
+	defer vn.loadingMutex.Unlock()
+	if vn.loading {
+		return
+	}
+	vn.loading = true
 
+	go func() {
+		vn.namesMutex.Lock()
+		vn.names = make(map[uint64]string)
+		vn.namesMutex.Unlock()
+
+		// load names
+		if utils.Config.Frontend.ValidatorNamesYaml != "" {
+			err := vn.loadFromYaml(utils.Config.Frontend.ValidatorNamesYaml)
+			if err != nil {
+				logger_vn.WithError(err).Errorf("error while loading validator names from yaml")
+			}
+		}
+		if utils.Config.Frontend.ValidatorNamesInventory != "" {
+			err := vn.loadFromRangesApi(utils.Config.Frontend.ValidatorNamesInventory)
+			if err != nil {
+				logger_vn.WithError(err).Errorf("error while loading validator names inventory")
+			}
+		}
+
+		// update db
+		vn.updateDb()
+
+		vn.loading = false
+	}()
+}
+
+func (vn *ValidatorNames) loadFromYaml(fileName string) error {
 	f, err := os.Open(fileName)
 	if err != nil {
-		logrus.Errorf("error opening validator names file %v: %v", fileName, err)
 		return fmt.Errorf("error opening validator names file %v: %v", fileName, err)
 	}
 
@@ -43,14 +82,12 @@ func (vn *ValidatorNames) LoadFromYaml(fileName string) error {
 	decoder := yaml.NewDecoder(f)
 	err = decoder.Decode(&namesYaml)
 	if err != nil {
-		logrus.Errorf("error decoding validator names file %v: %v", fileName, err)
 		return fmt.Errorf("error decoding validator names file %v: %v", fileName, err)
 	}
 
+	vn.namesMutex.Lock()
+	defer vn.namesMutex.Unlock()
 	nameCount := 0
-	if vn.names == nil {
-		vn.names = make(map[uint64]string)
-	}
 	for idxStr, name := range namesYaml {
 		rangeParts := strings.Split(idxStr, "-")
 		minIdx, err := strconv.ParseUint(rangeParts[0], 10, 64)
@@ -69,7 +106,7 @@ func (vn *ValidatorNames) LoadFromYaml(fileName string) error {
 			nameCount++
 		}
 	}
-	logrus.Infof("Loaded %v validator names from yaml (%v)", nameCount, fileName)
+	logger_vn.Infof("loaded %v validator names from yaml (%v)", nameCount, fileName)
 
 	return nil
 }
@@ -78,25 +115,22 @@ type validatorNamesRangesResponse struct {
 	Ranges map[string]string `json:"ranges"`
 }
 
-func (vn *ValidatorNames) LoadFromRangesApi(apiUrl string) error {
-	vn.namesMutex.Lock()
-	defer vn.namesMutex.Unlock()
-	logrus.Debugf("Loading validator names from inventory: %v", apiUrl)
+func (vn *ValidatorNames) loadFromRangesApi(apiUrl string) error {
+	logger_vn.Debugf("Loading validator names from inventory: %v", apiUrl)
 
 	client := &http.Client{Timeout: time.Second * 120}
 	resp, err := client.Get(apiUrl)
 	if err != nil {
-		logrus.Errorf("Could not fetch validator names from inventory (%v): %v", apiUrl, err)
-		return err
+		return fmt.Errorf("could not fetch inventory (%v): %v", utils.GetRedactedUrl(apiUrl), err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusNotFound {
-			logrus.Errorf("Could not fetch validator names from inventory (%v): not found", apiUrl)
+			logger_vn.Errorf("could not fetch inventory (%v): not found", utils.GetRedactedUrl(apiUrl))
 			return nil
 		}
 		data, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("url: %v, error-response: %s", apiUrl, data)
+		return fmt.Errorf("url: %v, error-response: %s", utils.GetRedactedUrl(apiUrl), data)
 	}
 	rangesResponse := &validatorNamesRangesResponse{}
 	dec := json.NewDecoder(resp.Body)
@@ -105,9 +139,8 @@ func (vn *ValidatorNames) LoadFromRangesApi(apiUrl string) error {
 		return fmt.Errorf("error parsing validator ranges response: %v", err)
 	}
 
-	if vn.names == nil {
-		vn.names = make(map[uint64]string)
-	}
+	vn.namesMutex.Lock()
+	defer vn.namesMutex.Unlock()
 	nameCount := 0
 	for rangeStr, name := range rangesResponse.Ranges {
 		rangeParts := strings.Split(rangeStr, "-")
@@ -127,6 +160,50 @@ func (vn *ValidatorNames) LoadFromRangesApi(apiUrl string) error {
 			nameCount++
 		}
 	}
-	logrus.Infof("Loaded %v validator names from inventory api (%v)", nameCount, apiUrl)
+	logger_vn.Infof("loaded %v validator names from inventory api (%v)", nameCount, utils.GetRedactedUrl(apiUrl))
+	return nil
+}
+
+func (vn *ValidatorNames) updateDb() error {
+	// save blocks
+	tx, err := db.WriterDb.Beginx()
+	if err != nil {
+		return fmt.Errorf("error starting db transaction: %v", err)
+	}
+	defer tx.Rollback()
+
+	err = db.ClearValidatorNames(tx)
+	if err != nil {
+		return fmt.Errorf("error clearing old validator names: %v", err)
+	}
+
+	vn.namesMutex.RLock()
+	nameRows := make([]*dbtypes.ValidatorName, 0)
+	for index, name := range vn.names {
+		nameRows = append(nameRows, &dbtypes.ValidatorName{
+			Index: index,
+			Name:  name,
+		})
+	}
+	vn.namesMutex.RUnlock()
+
+	nameIdx := 0
+	nameLen := len(nameRows)
+	for nameIdx < nameLen {
+		maxIdx := nameIdx + 1000
+		if maxIdx >= nameLen {
+			maxIdx = nameLen - 1
+		}
+		err := db.InsertValidatorNames(nameRows[nameIdx:maxIdx], tx)
+		if err != nil {
+			logger_vn.WithError(err).Errorf("error while adding validator names to db")
+		}
+		nameIdx = maxIdx + 1
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("error committing db transaction: %v", err)
+	}
+
 	return nil
 }

--- a/static/js/explorer.js
+++ b/static/js/explorer.js
@@ -221,7 +221,7 @@
         // sug.graffiti is html-escaped to prevent xss, we need to unescape it
         var el = document.createElement("textarea")
         el.innerHTML = sug.graffiti
-        window.location = "/slots?q=" + encodeURIComponent(el.value)
+        window.location = "/slots/filtered?f.graffiti=" + encodeURIComponent(el.value)
       } else {
         console.log("invalid typeahead-selection", sug)
       }

--- a/static/js/explorer.js
+++ b/static/js/explorer.js
@@ -221,7 +221,7 @@
         // sug.graffiti is html-escaped to prevent xss, we need to unescape it
         var el = document.createElement("textarea")
         el.innerHTML = sug.graffiti
-        window.location = "/slots/filtered?f.graffiti=" + encodeURIComponent(el.value)
+        window.location = "/slots/filtered?f&f.graffiti=" + encodeURIComponent(el.value)
       } else {
         console.log("invalid typeahead-selection", sug)
       }

--- a/templates/epochs/epochs.html
+++ b/templates/epochs/epochs.html
@@ -13,7 +13,6 @@
     </div>
 
     <div class="card mt-2">
-      <div id="header-placeholder" style="height:45px;"></div>
       <div class="card-body px-0 py-3">
         <div class="row">
           <div class="col-sm-12 col-md-6 table-pagesize">

--- a/templates/slots/slots.html
+++ b/templates/slots/slots.html
@@ -11,7 +11,6 @@
     </div>
 
     <div class="card mt-2">
-      <div id="header-placeholder" style="height:45px;"></div>
       <div class="card-body px-0 py-3">
         <div class="row">
           <div class="col-sm-12 col-md-6 table-pagesize">
@@ -34,13 +33,9 @@
           </div>
           <div class="col-sm-12 col-md-6 table-search">
             <div class="px-2" style="text-align: right;">
-              <form action="/slots/filtered" method="get">
-                <label>
-                  <input name="f" type="hidden" value="1">
-                  <input name="f.graffiti" type="search" class="form-control form-control-sm" placeholder="Search by Graffiti" aria-controls="graffiti" value="">
-                  <input name="f.orphaned" type="hidden" value="1">
-                </label>
-              </form>
+              <a href="/slots/filtered">
+                <i class="fas fa-filter mx-2"></i>Filter Blocks
+              </a>
             </div>
           </div>
         </div>

--- a/templates/slots_filtered/slots_filtered.html
+++ b/templates/slots_filtered/slots_filtered.html
@@ -1,54 +1,118 @@
 {{ define "page" }}
   <div class="container mt-2">
     <div class="d-md-flex py-2 justify-content-md-between">
-      <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-cube mx-2"></i>Slots</h1>
+      <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-cube mx-2"></i>Filtered Slots</h1>
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb font-size-1 mb-0" style="padding:0; background-color:transparent;">
           <li class="breadcrumb-item"><a href="/" title="Home">Home</a></li>
-          <li class="breadcrumb-item active" aria-current="page">Slots</li>
+          <li class="breadcrumb-item"><a href="/slots" title="Slots">Slots</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Filtered</li>
         </ol>
       </nav>
     </div>
 
-    <div class="card mt-2">
-      <div id="header-placeholder" style="height:45px;"></div>
-      <div class="card-body px-0 py-3">
-        <div class="row">
-          <div class="col-sm-12 col-md-6 table-pagesize">
-            <form action="/slots" method="get">
+    <div id="header-placeholder" style="height:35px;"></div>
+    <form action="/slots/filtered" method="get" id="slotsFilterForm">
+      <div class="card mt-2">
+        <div class="card-header">
+          Slot Filters
+        </div>
+        <div class="card-body p-2">
+          <div class="row">
+            <div class="col-sm-12 col-md-6">
+              <div class="container">
+                <div class="row mt-1">
+                  <div class="col-sm-12 col-md-6 col-lg-4">
+                    Graffiti
+                  </div>
+                  <div class="col-sm-12 col-md-6 col-lg-8">
+                    <input name="f.graffiti" type="text" class="form-control" placeholder="Graffiti" aria-label="Graffiti" aria-describedby="basic-addon1" value="{{ .FilterGraffiti }}">
+                  </div>
+                </div>
+                <div class="row mt-1">
+                  <div class="col-sm-12 col-md-6 col-lg-4">
+                    Proposer Index
+                  </div>
+                  <div class="col-sm-12 col-md-6 col-lg-8">
+                    <input name="f.proposer" type="number" class="form-control" placeholder="Proposer Index" aria-label="Proposer Index" aria-describedby="basic-addon1" value="{{ .FilterProposer }}">
+                  </div>
+                </div>
+                <div class="row mt-1">
+                  <div class="col-sm-12 col-md-6 col-lg-4">
+                    Proposer Name
+                  </div>
+                  <div class="col-sm-12 col-md-6 col-lg-8">
+                    <input name="f.pname" type="text" class="form-control" placeholder="Proposer Name" aria-label="Proposer Name" aria-describedby="basic-addon1" value="{{ .FilterProposerName }}">
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="col-sm-12 col-md-6">
+              <div class="container">
+                <div class="row mt-1">
+                  <div class="col-sm-12 col-md-6 col-lg-4">
+                    <nobr>Missing Blocks</nobr>
+                  </div>
+                  <div class="col-sm-12 col-md-6 col-lg-4">
+                    <select name="f.missing" aria-controls="missing" class="form-control">
+                      <option value="0" {{ if eq .FilterWithMissing 0 }}selected{{ end }}>Hide missing</option>
+                      <option value="1" {{ if eq .FilterWithMissing 1 }}selected{{ end }}>Show all</option>
+                      <option value="2" {{ if eq .FilterWithMissing 2 }}selected{{ end }}>Missing only</option>
+                    </select>
+                  </div>
+                </div>
+                <div class="row mt-1">
+                  <div class="col-sm-12 col-md-6 col-lg-4">
+                    <nobr>Orphaned Blocks</nobr>
+                  </div>
+                  <div class="col-sm-12 col-md-6 col-lg-4">
+                    <select name="f.orphaned" aria-controls="orphaned" class="form-control">
+                      <option value="0" {{ if eq .FilterWithOrphaned 0 }}selected{{ end }}>Hide orphaned</option>
+                      <option value="1" {{ if eq .FilterWithOrphaned 1 }}selected{{ end }}>Show all</option>
+                      <option value="2" {{ if eq .FilterWithOrphaned 2 }}selected{{ end }}>Orphaned only</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+          </div>
+          <div class="row mt-3">
+            <div class="col-8 col-md-6 table-pagesize">
               <label class="px-2">
                 <span>Show </span>
-                <select name="c" aria-controls="slots" class="custom-select custom-select-sm form-control form-control-sm" onchange="this.form.submit()">
+                <select name="c" aria-controls="slots" class="custom-select custom-select-sm form-control form-control-sm">
                   <option value="{{ .PageSize }}" selected>{{ .PageSize }}</option>
                   <option value="10">10</option>
                   <option value="25">25</option>
                   <option value="50">50</option>
                   <option value="100">100</option>
                 </select>
-                {{ if not .IsDefaultPage }}
-                  <input name="s" type="hidden" value="{{ .CurrentPageSlot }}">
-                {{ end }}
-                <span> entries</span>
+                <span> entries per page</span>
               </label>
-            </form>
-          </div>
-          <div class="col-sm-12 col-md-6 table-search">
-            <div class="px-2" style="text-align: right;">
-              <form action="/slots/filtered" method="get">
-                <label>
-                  <input name="f" type="hidden" value="1">
-                  <input name="f.graffiti" type="search" class="form-control form-control-sm" placeholder="Search by Graffiti" aria-controls="graffiti" value="">
-                  <input name="f.orphaned" type="hidden" value="1">
-                </label>
-              </form>
+            </div>
+            <div class="col-4 col-md-6">
+              <div class="container text-end">
+                <button type="submit" class="btn btn-primary">Apply Filter</button>
+              </div>
             </div>
           </div>
         </div>
+      </div>
+    </form>
+    <script type="text/javascript">
+      $('#slotsFilterForm').submit(function () {
+        $(this).find('input[type="text"],input[type="number"]').filter(function () { return !this.value; }).prop('name', '');
+      });
+    </script>
+
+    <div class="card mt-2">
+      <div class="card-body px-0 py-3">
+            
         <div class="table-responsive px-0 py-1">
           <table class="table table-nobr" id="slots">
             <thead>
               <tr>
-                <th>Chain</th>
                 <th>Epoch</th>
                 <th>Slot</th>
                 <th>Status</th>
@@ -70,23 +134,8 @@
             </thead>
             {{ if gt .SlotCount 0 }}
               <tbody>
-                {{ $treeWidth := .ForkTreeWidth }}
                 {{ range $i, $slot := .Slots }}
                   <tr>
-                    <td class="graph-container" style="min-width: {{ $treeWidth }}px;">
-                      {{ range $j, $graph := $slot.ForkGraph }}
-                        <div class="graph-fork" data-index="{{ $graph.Index }}" style="left: {{ $graph.Left }}px;">
-                          {{- range $tile, $val := $graph.Tiles -}}
-                            <div class="graph-layer graph-layer-{{ $tile }}"></div>
-                          {{- end -}}
-                          {{- if $graph.Block }}
-                            <div class="graph-layer graph-layer-block">
-                              <i class="fas fa-circle"></i>
-                            </div>
-                          {{ end -}}
-                        </div>
-                      {{ end }}
-                    </td>
                     <td><a href="/epoch/{{ $slot.Epoch }}">{{ formatAddCommas $slot.Epoch }}</a></td>
                     {{ if eq $slot.Status 2 }}
                       <td><a href="/slot/0x{{ printf "%x" $slot.BlockRoot }}">{{ formatAddCommas $slot.Slot }}</a></td>
@@ -152,19 +201,19 @@
               <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if le .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
-                    <a tab-index="1" aria-controls="tpg_first" class="page-link" href="/slots?c={{ .PageSize }}">First</a>
+                    <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
                   </li>
                   <li class="previous paginate_button page-item {{ if eq .PrevPageIndex 0 }}disabled{{ end }}" id="tpg_previous">
-                    <a tab-index="1" aria-controls="tpg_previous" class="page-link" href="/slots?s={{ .PrevPageSlot }}&c={{ .PageSize }}"><i class="fas fa-chevron-left"></i></a>
+                    <a tab-index="1" aria-controls="tpg_previous" class="page-link" href="{{ .PrevPageLink }}"><i class="fas fa-chevron-left"></i></a>
                   </li>
                   <li class="page-item disabled">
                     <a class="page-link" style="background-color: transparent;">{{ .CurrentPageIndex }} of {{ .TotalPages }}</a>
                   </li>
                   <li class="next paginate_button page-item {{ if eq .NextPageIndex 0 }}disabled{{ end }}" id="tpg_next">
-                    <a tab-index="1" aria-controls="tpg_next" class="page-link" href="/slots?s={{ .NextPageSlot }}&c={{ .PageSize }}"><i class="fas fa-chevron-right"></i></a>
+                    <a tab-index="1" aria-controls="tpg_next" class="page-link" href="{{ .NextPageLink }}"><i class="fas fa-chevron-right"></i></a>
                   </li>
                   <li class="last paginate_button page-item {{ if or (eq .LastPageSlot 0) (le .NextPageSlot .LastPageSlot) }}disabled{{ end }}" id="tpg_last">
-                    <a tab-index="1" aria-controls="tpg_last" class="page-link" href="/slots?s={{ .LastPageSlot }}&c={{ .PageSize }}">Last</a>
+                    <a tab-index="1" aria-controls="tpg_last" class="page-link" href="{{ .LastPageLink }}">Last</a>
                   </li>
                 </ul>
               </div>
@@ -179,5 +228,4 @@
 {{ define "js" }}
 {{ end }}
 {{ define "css" }}
-  <link rel="stylesheet" href="/css/forkgraph.css" />
 {{ end }}

--- a/templates/slots_filtered/slots_filtered.html
+++ b/templates/slots_filtered/slots_filtered.html
@@ -146,16 +146,16 @@
                     <td>
                       {{ if eq $slot.Slot 0 }}
                         <span class="badge rounded-pill text-bg-info">Genesis</span>
+                      {{ else if eq $slot.Status 1 }}
+                        <span class="badge rounded-pill text-bg-success">Proposed</span>
+                      {{ else if eq $slot.Status 2 }}
+                        <span class="badge rounded-pill text-bg-info">Orphaned</span>
                       {{ else if $slot.Scheduled }}
                         <span class="badge rounded-pill text-bg-secondary">Scheduled</span>
                       {{ else if not $slot.Synchronized }}
                         <span class="badge rounded-pill text-bg-secondary">?</span>
                       {{ else if eq $slot.Status 0 }}
                         <span class="badge rounded-pill text-bg-warning">Missed</span>
-                      {{ else if eq $slot.Status 1 }}
-                        <span class="badge rounded-pill text-bg-success">Proposed</span>
-                      {{ else if eq $slot.Status 2 }}
-                        <span class="badge rounded-pill text-bg-info">Orphaned</span>
                       {{ else }}
                         <span class="badge rounded-pill text-bg-dark">Unknown</span>
                       {{ end }}

--- a/templates/slots_filtered/slots_filtered.html
+++ b/templates/slots_filtered/slots_filtered.html
@@ -13,6 +13,7 @@
 
     <div id="header-placeholder" style="height:35px;"></div>
     <form action="/slots/filtered" method="get" id="slotsFilterForm">
+      <input type="hidden" name="f">
       <div class="card mt-2">
         <div class="card-header">
           Slot Filters

--- a/templates/validators/validators.html
+++ b/templates/validators/validators.html
@@ -12,7 +12,6 @@
     </div>
 
     <div class="card mt-2">
-      <div id="header-placeholder" style="height:45px;"></div>
       <div class="card-body px-0 py-3">
         <div class="row">
           <div class="col-sm-12 col-md-6 table-pagesize">

--- a/types/models/slots.go
+++ b/types/models/slots.go
@@ -6,13 +6,11 @@ import (
 
 // SlotsPageData is a struct to hold info for the slots page
 type SlotsPageData struct {
-	Slots          []*SlotsPageDataSlot `json:"slots"`
-	SlotCount      uint64               `json:"slot_count"`
-	FirstSlot      uint64               `json:"first_slot"`
-	LastSlot       uint64               `json:"last_slot"`
-	ShowForkTree   bool                 `json:"show_forktree"`
-	ForkTreeWidth  int                  `json:"forktree_width"`
-	GraffitiFilter string               `json:"graffiti_filter"`
+	Slots         []*SlotsPageDataSlot `json:"slots"`
+	SlotCount     uint64               `json:"slot_count"`
+	FirstSlot     uint64               `json:"first_slot"`
+	LastSlot      uint64               `json:"last_slot"`
+	ForkTreeWidth int                  `json:"forktree_width"`
 
 	IsDefaultPage    bool   `json:"default_page"`
 	TotalPages       uint64 `json:"total_pages"`

--- a/types/models/slots_filtered.go
+++ b/types/models/slots_filtered.go
@@ -1,0 +1,58 @@
+package models
+
+import (
+	"time"
+)
+
+// SlotsPageData is a struct to hold info for the slots page
+type SlotsFilteredPageData struct {
+	FilterGraffiti     string `json:"filter_graffiti"`
+	FilterProposer     string `json:"filter_proposer"`
+	FilterProposerName string `json:"filter_pname"`
+	FilterWithOrphaned uint8  `json:"filter_orphaned"`
+	FilterWithMissing  uint8  `json:"filter_missing"`
+
+	Slots     []*SlotsFilteredPageDataSlot `json:"slots"`
+	SlotCount uint64                       `json:"slot_count"`
+	FirstSlot uint64                       `json:"first_slot"`
+	LastSlot  uint64                       `json:"last_slot"`
+
+	IsDefaultPage    bool   `json:"default_page"`
+	TotalPages       uint64 `json:"total_pages"`
+	PageSize         uint64 `json:"page_size"`
+	CurrentPageIndex uint64 `json:"page_index"`
+	CurrentPageSlot  uint64 `json:"page_slot"`
+	PrevPageIndex    uint64 `json:"prev_page_index"`
+	PrevPageSlot     uint64 `json:"prev_page_slot"`
+	NextPageIndex    uint64 `json:"next_page_index"`
+	NextPageSlot     uint64 `json:"next_page_slot"`
+	LastPageSlot     uint64 `json:"last_page_slot"`
+
+	FirstPageLink string `json:"first_page_link"`
+	PrevPageLink  string `json:"prev_page_link"`
+	NextPageLink  string `json:"next_page_link"`
+	LastPageLink  string `json:"last_page_link"`
+}
+
+type SlotsFilteredPageDataSlot struct {
+	Slot                  uint64    `json:"slot"`
+	Epoch                 uint64    `json:"epoch"`
+	Ts                    time.Time `json:"ts"`
+	Finalized             bool      `json:"scheduled"`
+	Scheduled             bool      `json:"finalized"`
+	Status                uint8     `json:"status"`
+	Synchronized          bool      `json:"synchronized"`
+	Proposer              uint64    `json:"proposer"`
+	ProposerName          string    `json:"proposer_name"`
+	AttestationCount      uint64    `json:"attestation_count"`
+	DepositCount          uint64    `json:"deposit_count"`
+	ExitCount             uint64    `json:"exit_count"`
+	ProposerSlashingCount uint64    `json:"proposer_slashing_count"`
+	AttesterSlashingCount uint64    `json:"attester_slashing_count"`
+	SyncParticipation     float64   `json:"sync_participation"`
+	EthTransactionCount   uint64    `json:"eth_transaction_count"`
+	EthBlockNumber        uint64    `json:"eth_block_number"`
+	Graffiti              []byte    `json:"graffiti"`
+	BlockRoot             []byte    `json:"block_root"`
+	ParentRoot            []byte    `json:"parent_root"`
+}


### PR DESCRIPTION

![image](https://github.com/pk910/light-beaconchain-explorer/assets/491045/85fec2a2-f6d4-4252-bb04-e5c3f7845bc9)


Added a separate slots page with advanced filtering.
Available filters:
* Block Graffiti (pattern)
* Proposer Index
* Proposer Name (pattern)
* Missing Status (Hide missing, Show all, Only missing)
* Orphaned Status (Hide orphaned, Show all, Only orphaned)