### PR TITLE
Sync committee assignment indexing & slot page speedup

### DIFF
--- a/db/schema/pgsql/20230906021153_sync-duties.sql
+++ b/db/schema/pgsql/20230906021153_sync-duties.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE IF NOT EXISTS public."sync_assignments"
+(
+    "period" bigint NOT NULL,
+    "index" int NOT NULL,
+    "validator" bigint NOT NULL,
+    CONSTRAINT "sync_assignments_pkey" PRIMARY KEY ("period", "index")
+);
+
+CREATE INDEX IF NOT EXISTS "sync_assignments_validator_idx"
+    ON public."sync_assignments" 
+    ("validator" ASC NULLS LAST);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/db/schema/sqlite/20230906021153_sync-duties.sql
+++ b/db/schema/sqlite/20230906021153_sync-duties.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE IF NOT EXISTS "sync_assignments"
+(
+    "period" bigint NOT NULL,
+    "index" int NOT NULL,
+    "validator" bigint NOT NULL,
+    CONSTRAINT "sync_assignments_pkey" PRIMARY KEY ("period", "index")
+);
+
+CREATE INDEX IF NOT EXISTS "sync_assignments_validator_idx"
+    ON "sync_assignments" 
+    ("validator" ASC);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/dbtypes/dbtypes.go
+++ b/dbtypes/dbtypes.go
@@ -71,6 +71,12 @@ type SlotAssignment struct {
 	Proposer uint64 `db:"proposer"`
 }
 
+type SyncAssignment struct {
+	Period    uint64 `db:"period"`
+	Index     uint32 `db:"index"`
+	Validator uint64 `db:"validator"`
+}
+
 type UnfinalizedBlock struct {
 	Root   []byte `db:"root"`
 	Slot   uint64 `db:"slot"`

--- a/indexer/cache_logic.go
+++ b/indexer/cache_logic.go
@@ -189,6 +189,12 @@ func (cache *indexerCache) processFinalizedEpoch(epoch uint64) error {
 		return err
 	}
 
+	err = persistSyncAssignments(epoch, epochStats, tx)
+	if err != nil {
+		logger.Errorf("error persisting sync committee assignments to db: %v", err)
+		return err
+	}
+
 	if len(blobs) > 0 {
 		for _, blob := range blobs {
 			err := cache.indexer.BlobStore.saveBlob(blob, tx)

--- a/indexer/epoch_stats.go
+++ b/indexer/epoch_stats.go
@@ -124,6 +124,14 @@ func (epochStats *EpochStats) GetProposerAssignments() map[uint64]uint64 {
 	return epochStats.proposerAssignments
 }
 
+func (epochStats *EpochStats) TryGetProposerAssignments() map[uint64]uint64 {
+	if !epochStats.dutiesMutex.TryRLock() {
+		return nil
+	}
+	defer epochStats.dutiesMutex.RUnlock()
+	return epochStats.proposerAssignments
+}
+
 func (epochStats *EpochStats) GetAttestorAssignments() map[string][]uint64 {
 	epochStats.dutiesMutex.RLock()
 	defer epochStats.dutiesMutex.RUnlock()
@@ -132,6 +140,14 @@ func (epochStats *EpochStats) GetAttestorAssignments() map[string][]uint64 {
 
 func (epochStats *EpochStats) GetSyncAssignments() []uint64 {
 	epochStats.dutiesMutex.RLock()
+	defer epochStats.dutiesMutex.RUnlock()
+	return epochStats.syncAssignments
+}
+
+func (epochStats *EpochStats) TryGetSyncAssignments() []uint64 {
+	if !epochStats.dutiesMutex.TryRLock() {
+		return nil
+	}
 	defer epochStats.dutiesMutex.RUnlock()
 	return epochStats.syncAssignments
 }

--- a/indexer/synchronizer.go
+++ b/indexer/synchronizer.go
@@ -273,6 +273,11 @@ func (sync *synchronizerState) syncEpoch(syncEpoch uint64, lastTry bool, skipCli
 		return false, client, fmt.Errorf("error persisting epoch data to db: %v", err)
 	}
 
+	err = persistSyncAssignments(syncEpoch, epochStats, tx)
+	if err != nil {
+		return false, client, fmt.Errorf("error persisting sync committee assignments to db: %v", err)
+	}
+
 	if len(blobs) > 0 {
 		for _, blob := range blobs {
 			err := sync.indexer.BlobStore.saveBlob(blob, tx)

--- a/templates/slot/slot.html
+++ b/templates/slot/slot.html
@@ -80,7 +80,15 @@
           <div class="card block-card">
             <div style="margin-bottom: -.25rem;" class="card-body px-0 py-1">
               <div class="row p-1 mx-0">
-                <h3 class="h5 col-md-12 text-center"><b>Showing {{ .Block.AttestationsCount }} Attestations </b></h3>
+                <div class="d-none d-md-block col-md-4"></div>
+                <h3 class="h5 col-12 col-md-4 text-center">
+                  <b>Showing {{ .Block.AttestationsCount }} Attestations</b>
+                </h3>
+                <div class="col-md-4 text-center text-md-end">
+                  {{ if not .Block.DutiesLoaded -}}
+                  <a class="btn btn-primary" href="?duties=1#attestations" role="button" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="This might take a few seconds">Load Validator Indexes</a>
+                  {{- end }}
+                </div>
               </div>
             </div>
           </div>

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -51,8 +51,9 @@ type SlotPageBlockData struct {
 	WithdrawalsCount       uint64                 `json:"withdrawals_count"`
 	BLSChangesCount        uint64                 `json:"bls_changes_count"`
 	VoluntaryExitsCount    uint64                 `json:"voluntaryexits_count"`
-	SlashingsCount         uint64
-	BlobsCount             uint64 `json:"blobs_count"`
+	SlashingsCount         uint64                 `json:"slashings_count"`
+	BlobsCount             uint64                 `json:"blobs_count"`
+	DutiesLoaded           bool                   `json:"duties_loaded"`
 
 	ExecutionData     *SlotPageExecutionData      `json:"execution_data"`
 	Attestations      []*SlotPageAttestation      `json:"attestations"`       // Attestations included in this block


### PR DESCRIPTION
This PR adds a separate table for sync committee assignments to the database.
The indexer & synchronizer are now indexing sync committee assignments.

I've also modified the slot details page, so by default it does not load epoch duties from RPC anymore.
(This caused some high loading times when loading epoch duties for old epochs)

Proposer & Sync committee assignments are now loaded from db when showing a slot details page.

Attestation assignments are no longer shown by default. But it can be requested if anyone needs them via a button.