### PR TITLE
fix: deposit page

### DIFF
--- a/services/chainservice_deposits.go
+++ b/services/chainservice_deposits.go
@@ -595,7 +595,7 @@ func (bs *ChainService) getLastIncludedDeposit(headRoot phase0.Root) *dbtypes.De
 		}, nil)
 		if err != nil {
 			logrus.Warnf("ChainService.getLastIncludedDeposit error: %v", err)
-		} else {
+		} else if len(dbDeposits) > 0 {
 			return &dbDeposits[0].Deposit
 		}
 	}


### PR DESCRIPTION
Fixing panic: 
```
URL: /validator/746
Time: 2025-04-08 12:01:27.082356832 +0000 UTC m=+338.690588410
Version: git-820fcd0

Error:
page call 19 panic: runtime error: index out of range [0] with length 0

Stack Trace:
goroutine 1138 [running]:
runtime/debug.Stack()
    /opt/hostedtoolcache/go/1.24.2/x64/src/runtime/debug/stack.go:26 +0x5e
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1.1()
    /home/runner/work/dora/dora/services/frontendcache.go:131 +0xd4
panic({0x1ae9300?, 0xc000c21cb0?})
    /opt/hostedtoolcache/go/1.24.2/x64/src/runtime/panic.go:792 +0x132
github.com/ethpandaops/dora/services.(*ChainService).getLastIncludedDeposit(0xc0003a72c0, {0x45, 0xad, 0xa9, 0x5d, 0x14, 0x9d, 0x30, 0xc6, 0x88, ...})
    /home/runner/work/dora/dora/services/chainservice_deposits.go:599 +0x32b
github.com/ethpandaops/dora/services.(*ChainService).GetIndexedDepositQueue(0xc0003a72c0, 0x0?)
    /home/runner/work/dora/dora/services/chainservice_deposits.go:392 +0xac
github.com/ethpandaops/dora/services.(*ChainService).GetFilteredQueuedDeposits(0xc0003a72c0, 0xc0022f7e50)
    /home/runner/work/dora/dora/services/chainservice_deposits.go:621 +0x45
github.com/ethpandaops/dora/handlers.buildValidatorPageData(0x2ea, {0x1bd2857, 0x6})
    /home/runner/work/dora/dora/handlers/validator.go:140 +0x3c7
github.com/ethpandaops/dora/handlers.getValidatorPageData.func1(0xc0023c6240)
    /home/runner/work/dora/dora/handlers/validator.go:102 +0x25
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1(0xc001ca4fc0?)
    /home/runner/work/dora/dora/services/frontendcache.go:148 +0x1d3
created by github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall in goroutine 725
    /home/runner/work/dora/dora/services/frontendcache.go:125 +0x348
    ```