### PR TITLE
fix: handle Gloas in GetForkVersionAtEpoch

### DIFF
--- a/clients/consensus/chainstate.go
+++ b/clients/consensus/chainstate.go
@@ -439,6 +439,8 @@ func (cs *ChainState) GetForkVersionAtEpoch(epoch phase0.Epoch) phase0.Version {
 	switch {
 	case cs.specs.HezeForkEpoch != nil && epoch >= phase0.Epoch(*cs.specs.HezeForkEpoch):
 		return cs.specs.HezeForkVersion
+	case cs.specs.GloasForkEpoch != nil && epoch >= phase0.Epoch(*cs.specs.GloasForkEpoch):
+		return cs.specs.GloasForkVersion
 	case cs.specs.FuluForkEpoch != nil && epoch >= phase0.Epoch(*cs.specs.FuluForkEpoch):
 		return cs.specs.FuluForkVersion
 	case cs.specs.ElectraForkEpoch != nil && epoch >= phase0.Epoch(*cs.specs.ElectraForkEpoch):


### PR DESCRIPTION
\`ChainState.GetForkVersionAtEpoch\` had no case for Gloas, so any post-Gloas pre-Heze epoch fell through to Fulu and returned \`FuluForkVersion\`. Every \`CurrentForkDigest\` derivation was therefore wrong — most visibly, the DAS Guardian check marked peers reporting the correct Gloas digest as Invalid.

Repro on local ePBS enclave (Gloas@3, current epoch 19): peer reports \`0x55ddc618\` (Gloas), dora rendered \`0x6ed89b4e\` (Fulu) → Invalid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)