### PR TITLE
fix: detect nimbus-eth1 by new `Nimbus/` client version prefix

### DIFF
--- a/clients/execution/clienttype.go
+++ b/clients/execution/clienttype.go
@@ -26,7 +26,7 @@ var clientTypePatterns = map[ClientType]*regexp.Regexp{
 	GethClient:       regexp.MustCompile("(?i)^Geth/.*"),
 	NethermindClient: regexp.MustCompile("(?i)^Nethermind/.*"),
 	RethClient:       regexp.MustCompile("(?i)^Reth/.*"),
-	NimbusELClient:   regexp.MustCompile("(?i)^(nimbus-eth1|NimbusExecutionClient)/.*"),
+	NimbusELClient:   regexp.MustCompile("(?i)^(nimbus-eth1|NimbusExecutionClient|Nimbus)/.*"),
 	EthrexClient:     regexp.MustCompile("(?i)^ethrex/.*"),
 }
 


### PR DESCRIPTION
## Summary
- nimbus-eth1 now reports `web3_clientVersion` as `Nimbus/v0.3.0-<sha>/<os>-<arch>/Nim-<ver>`, which no longer matches the existing regex (`^(nimbus-eth1|NimbusExecutionClient)/`). The Exec Time tooltip on the slots page therefore fell back to `Unknown(0)` for every nimbusel timing sample.
- Extend the `NimbusELClient` regex alternation with `Nimbus` so the bare prefix is detected while keeping backwards compatibility with the older `nimbus-eth1` / `NimbusExecutionClient` values.

## Test plan
- [x] Kurtosis devnet with `el_type: nimbus` + `snooper_enabled: true`
- [x] Verified `/slots` page now renders `client_type: nimbusel` in the `exec-time-display` payload (previously `Unknown(0)`)
- [x] Confirmed geth timings on the same devnet continue to be labelled `geth`