### PR TITLE
make execution index more compact

### DIFF
--- a/db/el_cleanup.go
+++ b/db/el_cleanup.go
@@ -28,36 +28,40 @@ func DeleteElDataBeforeBlockUid(ctx context.Context, blockUidThreshold uint64, _
 	batchSize := int64(50000)
 	stats := &CleanupStats{}
 
-	// Delete transactions in batches
-	deleted, err := batchDeleteBeforeBlockUid(ctx, "el_transactions", blockUidThreshold, batchSize)
+	// tx_uid encodes block_uid in upper bits: tx_uid = block_uid << 16 | tx_index.
+	// All tx_uids for blocks below the threshold satisfy tx_uid < txUidThreshold.
+	txUidThreshold := blockUidThreshold << 16
+
+	// Delete transactions in batches (uses block_uid column)
+	deleted, err := batchDeleteBefore(ctx, "el_transactions", "block_uid", blockUidThreshold, batchSize)
 	if err != nil {
 		return stats, err
 	}
 	stats.TransactionsDeleted = deleted
 
-	// Delete internal transactions in batches
-	deleted, err = batchDeleteBeforeBlockUid(ctx, "el_transactions_internal", blockUidThreshold, batchSize)
+	// Delete internal transactions in batches (uses tx_uid column)
+	deleted, err = batchDeleteBefore(ctx, "el_transactions_internal", "tx_uid", txUidThreshold, batchSize)
 	if err != nil {
 		return stats, err
 	}
 	stats.InternalTxsDeleted = deleted
 
-	// Delete event index entries in batches
-	deleted, err = batchDeleteBeforeBlockUid(ctx, "el_event_index", blockUidThreshold, batchSize)
+	// Delete event index entries in batches (uses tx_uid column)
+	deleted, err = batchDeleteBefore(ctx, "el_event_index", "tx_uid", txUidThreshold, batchSize)
 	if err != nil {
 		return stats, err
 	}
 	stats.EventIndicesDeleted = deleted
 
-	// Delete token transfers in batches
-	deleted, err = batchDeleteBeforeBlockUid(ctx, "el_token_transfers", blockUidThreshold, batchSize)
+	// Delete token transfers in batches (uses tx_uid column)
+	deleted, err = batchDeleteBefore(ctx, "el_token_transfers", "tx_uid", txUidThreshold, batchSize)
 	if err != nil {
 		return stats, err
 	}
 	stats.TokenTransfersDeleted = deleted
 
-	// Delete blocks in batches
-	deleted, err = batchDeleteBeforeBlockUid(ctx, "el_blocks", blockUidThreshold, batchSize)
+	// Delete blocks in batches (uses block_uid column)
+	deleted, err = batchDeleteBefore(ctx, "el_blocks", "block_uid", blockUidThreshold, batchSize)
 	if err != nil {
 		return stats, err
 	}
@@ -66,9 +70,9 @@ func DeleteElDataBeforeBlockUid(ctx context.Context, blockUidThreshold uint64, _
 	return stats, nil
 }
 
-// batchDeleteBeforeBlockUid deletes rows from a table where block_uid < threshold,
+// batchDeleteBefore deletes rows from a table where the given column < threshold,
 // in batches of batchSize to avoid long locks.
-func batchDeleteBeforeBlockUid(ctx context.Context, table string, blockUidThreshold uint64, batchSize int64) (int64, error) {
+func batchDeleteBefore(ctx context.Context, table string, column string, threshold uint64, batchSize int64) (int64, error) {
 	var totalDeleted int64
 
 	for {
@@ -77,22 +81,22 @@ func batchDeleteBeforeBlockUid(ctx context.Context, table string, blockUidThresh
 			var query string
 			if DbEngine == dbtypes.DBEnginePgsql {
 				query = `DELETE FROM ` + table + `
-					WHERE block_uid < $1
+					WHERE ` + column + ` < $1
 					AND ctid IN (
 						SELECT ctid FROM ` + table + `
-						WHERE block_uid < $1
+						WHERE ` + column + ` < $1
 						LIMIT $2
 					)`
 			} else {
 				query = `DELETE FROM ` + table + `
-					WHERE block_uid < $1
+					WHERE ` + column + ` < $1
 					AND rowid IN (
 						SELECT rowid FROM ` + table + `
-						WHERE block_uid < $1
+						WHERE ` + column + ` < $1
 						LIMIT $2
 					)`
 			}
-			result, err := tx.ExecContext(ctx, query, blockUidThreshold, batchSize)
+			result, err := tx.ExecContext(ctx, query, threshold, batchSize)
 			if err != nil {
 				return err
 			}

--- a/db/el_event_index.go
+++ b/db/el_event_index.go
@@ -21,12 +21,12 @@ func InsertElEventIndices(ctx context.Context, dbTx *sqlx.Tx, entries []*dbtypes
 			dbtypes.DBEnginePgsql:  "INSERT INTO el_event_index ",
 			dbtypes.DBEngineSqlite: "INSERT OR REPLACE INTO el_event_index ",
 		}),
-		"(block_uid, tx_hash, event_index, source_id, topic1)",
+		"(tx_uid, event_index, source_id, topic1)",
 		" VALUES ",
 	)
 
 	argIdx := 0
-	fieldCount := 5
+	fieldCount := 4
 	args := make([]any, len(entries)*fieldCount)
 
 	for i, entry := range entries {
@@ -42,16 +42,15 @@ func InsertElEventIndices(ctx context.Context, dbTx *sqlx.Tx, entries []*dbtypes
 		}
 		fmt.Fprint(&sql, ")")
 
-		args[argIdx+0] = entry.BlockUid
-		args[argIdx+1] = entry.TxHash
-		args[argIdx+2] = entry.EventIndex
-		args[argIdx+3] = entry.SourceID
-		args[argIdx+4] = entry.Topic1
+		args[argIdx+0] = entry.TxUid
+		args[argIdx+1] = entry.EventIndex
+		args[argIdx+2] = entry.SourceID
+		args[argIdx+3] = entry.Topic1
 		argIdx += fieldCount
 	}
 
 	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
-		dbtypes.DBEnginePgsql: " ON CONFLICT (block_uid, tx_hash, event_index) DO UPDATE SET" +
+		dbtypes.DBEnginePgsql: " ON CONFLICT (tx_uid, event_index) DO UPDATE SET" +
 			" source_id = excluded.source_id," +
 			" topic1 = excluded.topic1",
 		dbtypes.DBEngineSqlite: "",
@@ -62,7 +61,7 @@ func InsertElEventIndices(ctx context.Context, dbTx *sqlx.Tx, entries []*dbtypes
 }
 
 // GetElEventIndicesBySource returns event index entries for a given
-// source contract, ordered by block_uid DESC.
+// source contract, ordered by tx_uid DESC.
 func GetElEventIndicesBySource(
 	ctx context.Context,
 	sourceID uint64,
@@ -74,7 +73,7 @@ func GetElEventIndicesBySource(
 
 	fmt.Fprint(&sql, `
 	WITH cte AS (
-		SELECT block_uid, tx_hash, event_index, source_id, topic1
+		SELECT tx_uid, event_index, source_id, topic1
 		FROM el_event_index
 		WHERE source_id = $1
 	)`)
@@ -82,15 +81,14 @@ func GetElEventIndicesBySource(
 	args = append(args, limit)
 	fmt.Fprintf(&sql, `
 	SELECT
-		count(*) AS block_uid,
-		null AS tx_hash,
+		count(*) AS tx_uid,
 		0 AS event_index,
 		0 AS source_id,
 		null AS topic1
 	FROM cte
 	UNION ALL SELECT * FROM (
 	SELECT * FROM cte
-	ORDER BY block_uid DESC NULLS LAST, tx_hash DESC, event_index ASC
+	ORDER BY tx_uid DESC NULLS LAST, event_index ASC
 	LIMIT $%v`, len(args))
 
 	if offset > 0 {
@@ -109,12 +107,12 @@ func GetElEventIndicesBySource(
 		return []*dbtypes.ElEventIndex{}, 0, nil
 	}
 
-	count := entries[0].BlockUid
+	count := entries[0].TxUid
 	return entries[1:], count, nil
 }
 
 // GetElEventIndicesByTopic1 returns event index entries for a given
-// event signature (topic1), ordered by block_uid DESC.
+// event signature (topic1), ordered by tx_uid DESC.
 func GetElEventIndicesByTopic1(
 	ctx context.Context,
 	topic1 []byte,
@@ -126,7 +124,7 @@ func GetElEventIndicesByTopic1(
 
 	fmt.Fprint(&sql, `
 	WITH cte AS (
-		SELECT block_uid, tx_hash, event_index, source_id, topic1
+		SELECT tx_uid, event_index, source_id, topic1
 		FROM el_event_index
 		WHERE topic1 = $1
 	)`)
@@ -134,15 +132,14 @@ func GetElEventIndicesByTopic1(
 	args = append(args, limit)
 	fmt.Fprintf(&sql, `
 	SELECT
-		count(*) AS block_uid,
-		null AS tx_hash,
+		count(*) AS tx_uid,
 		0 AS event_index,
 		0 AS source_id,
 		null AS topic1
 	FROM cte
 	UNION ALL SELECT * FROM (
 	SELECT * FROM cte
-	ORDER BY block_uid DESC NULLS LAST, tx_hash DESC, event_index ASC
+	ORDER BY tx_uid DESC NULLS LAST, event_index ASC
 	LIMIT $%v`, len(args))
 
 	if offset > 0 {
@@ -161,17 +158,17 @@ func GetElEventIndicesByTopic1(
 		return []*dbtypes.ElEventIndex{}, 0, nil
 	}
 
-	count := entries[0].BlockUid
+	count := entries[0].TxUid
 	return entries[1:], count, nil
 }
 
-// GetElEventIndexCountByTxHash returns the number of event index entries
-// for a given transaction hash. Uses an index-only scan for fast counting.
-func GetElEventIndexCountByTxHash(ctx context.Context, txHash []byte) (uint64, error) {
+// GetElEventIndexCountByTxUid returns the number of event index entries
+// for a given transaction UID.
+func GetElEventIndexCountByTxUid(ctx context.Context, txUid uint64) (uint64, error) {
 	var count uint64
 	err := ReaderDb.GetContext(ctx, &count,
-		"SELECT COUNT(*) FROM el_event_index WHERE tx_hash = $1",
-		txHash,
+		"SELECT COUNT(*) FROM el_event_index WHERE tx_uid = $1",
+		txUid,
 	)
 	if err != nil {
 		return 0, err
@@ -179,14 +176,14 @@ func GetElEventIndexCountByTxHash(ctx context.Context, txHash []byte) (uint64, e
 	return count, nil
 }
 
-// GetElEventIndicesByTxHash returns all event index entries for a
-// given transaction hash.
-func GetElEventIndicesByTxHash(ctx context.Context, txHash []byte) ([]*dbtypes.ElEventIndex, error) {
+// GetElEventIndicesByTxUid returns all event index entries for a
+// given transaction UID.
+func GetElEventIndicesByTxUid(ctx context.Context, txUid uint64) ([]*dbtypes.ElEventIndex, error) {
 	entries := []*dbtypes.ElEventIndex{}
 	err := ReaderDb.SelectContext(ctx, &entries,
-		"SELECT block_uid, tx_hash, event_index, source_id, topic1"+
-			" FROM el_event_index WHERE tx_hash = $1 ORDER BY event_index ASC",
-		txHash,
+		"SELECT tx_uid, event_index, source_id, topic1"+
+			" FROM el_event_index WHERE tx_uid = $1 ORDER BY event_index ASC",
+		txUid,
 	)
 	if err != nil {
 		return nil, err

--- a/db/el_token_transfers.go
+++ b/db/el_token_transfers.go
@@ -20,11 +20,11 @@ func InsertElTokenTransfers(ctx context.Context, dbTx *sqlx.Tx, transfers []*dbt
 			dbtypes.DBEnginePgsql:  "INSERT INTO el_token_transfers ",
 			dbtypes.DBEngineSqlite: "INSERT OR REPLACE INTO el_token_transfers ",
 		}),
-		"(block_uid, tx_hash, tx_pos, tx_idx, token_id, token_type, token_index, from_id, to_id, amount, amount_raw)",
+		"(tx_uid, tx_idx, token_id, token_type, token_index, from_id, to_id, amount, amount_raw)",
 		" VALUES ",
 	)
 	argIdx := 0
-	fieldCount := 11
+	fieldCount := 9
 
 	args := make([]any, len(transfers)*fieldCount)
 	for i, transfer := range transfers {
@@ -40,21 +40,19 @@ func InsertElTokenTransfers(ctx context.Context, dbTx *sqlx.Tx, transfers []*dbt
 		}
 		fmt.Fprint(&sql, ")")
 
-		args[argIdx+0] = transfer.BlockUid
-		args[argIdx+1] = transfer.TxHash
-		args[argIdx+2] = transfer.TxPos
-		args[argIdx+3] = transfer.TxIdx
-		args[argIdx+4] = transfer.TokenID
-		args[argIdx+5] = transfer.TokenType
-		args[argIdx+6] = transfer.TokenIndex
-		args[argIdx+7] = transfer.FromID
-		args[argIdx+8] = transfer.ToID
-		args[argIdx+9] = transfer.Amount
-		args[argIdx+10] = transfer.AmountRaw
+		args[argIdx+0] = transfer.TxUid
+		args[argIdx+1] = transfer.TxIdx
+		args[argIdx+2] = transfer.TokenID
+		args[argIdx+3] = transfer.TokenType
+		args[argIdx+4] = transfer.TokenIndex
+		args[argIdx+5] = transfer.FromID
+		args[argIdx+6] = transfer.ToID
+		args[argIdx+7] = transfer.Amount
+		args[argIdx+8] = transfer.AmountRaw
 		argIdx += fieldCount
 	}
 	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
-		dbtypes.DBEnginePgsql:  " ON CONFLICT (block_uid, tx_hash, tx_idx) DO UPDATE SET tx_pos = excluded.tx_pos, token_id = excluded.token_id, token_type = excluded.token_type, token_index = excluded.token_index, from_id = excluded.from_id, to_id = excluded.to_id, amount = excluded.amount, amount_raw = excluded.amount_raw",
+		dbtypes.DBEnginePgsql:  " ON CONFLICT (tx_uid, tx_idx) DO UPDATE SET token_id = excluded.token_id, token_type = excluded.token_type, token_index = excluded.token_index, from_id = excluded.from_id, to_id = excluded.to_id, amount = excluded.amount, amount_raw = excluded.amount_raw",
 		dbtypes.DBEngineSqlite: "",
 	}))
 
@@ -65,31 +63,22 @@ func InsertElTokenTransfers(ctx context.Context, dbTx *sqlx.Tx, transfers []*dbt
 	return nil
 }
 
-func GetElTokenTransfer(ctx context.Context, blockUid uint64, txHash []byte, txIdx uint32) (*dbtypes.ElTokenTransfer, error) {
+func GetElTokenTransfer(ctx context.Context, txUid uint64, txIdx uint32) (*dbtypes.ElTokenTransfer, error) {
 	transfer := &dbtypes.ElTokenTransfer{}
-	err := ReaderDb.GetContext(ctx, transfer, "SELECT block_uid, tx_hash, tx_pos, tx_idx, token_id, token_type, token_index, from_id, to_id, amount, amount_raw FROM el_token_transfers WHERE block_uid = $1 AND tx_hash = $2 AND tx_idx = $3", blockUid, txHash, txIdx)
+	err := ReaderDb.GetContext(ctx, transfer, "SELECT tx_uid, tx_idx, token_id, token_type, token_index, from_id, to_id, amount, amount_raw FROM el_token_transfers WHERE tx_uid = $1 AND tx_idx = $2", txUid, txIdx)
 	if err != nil {
 		return nil, err
 	}
 	return transfer, nil
 }
 
-func GetElTokenTransfersByTxHash(ctx context.Context, txHash []byte) ([]*dbtypes.ElTokenTransfer, error) {
-	transfers := []*dbtypes.ElTokenTransfer{}
-	err := ReaderDb.SelectContext(ctx, &transfers, "SELECT block_uid, tx_hash, tx_pos, tx_idx, token_id, token_type, token_index, from_id, to_id, amount, amount_raw FROM el_token_transfers WHERE tx_hash = $1 ORDER BY block_uid DESC, tx_pos DESC, tx_idx DESC", txHash)
-	if err != nil {
-		return nil, err
-	}
-	return transfers, nil
-}
-
-// GetElTokenTransferCountByBlockUidAndTxHash returns the number of token
-// transfers for a given block UID and transaction hash.
-func GetElTokenTransferCountByBlockUidAndTxHash(ctx context.Context, blockUid uint64, txHash []byte) (uint64, error) {
+// GetElTokenTransferCountByTxUid returns the number of token
+// transfers for a given transaction UID.
+func GetElTokenTransferCountByTxUid(ctx context.Context, txUid uint64) (uint64, error) {
 	var count uint64
 	err := ReaderDb.GetContext(ctx, &count,
-		"SELECT COUNT(*) FROM el_token_transfers WHERE block_uid = $1 AND tx_hash = $2",
-		blockUid, txHash,
+		"SELECT COUNT(*) FROM el_token_transfers WHERE tx_uid = $1",
+		txUid,
 	)
 	if err != nil {
 		return 0, err
@@ -97,18 +86,9 @@ func GetElTokenTransferCountByBlockUidAndTxHash(ctx context.Context, blockUid ui
 	return count, nil
 }
 
-func GetElTokenTransfersByBlockUid(ctx context.Context, blockUid uint64) ([]*dbtypes.ElTokenTransfer, error) {
+func GetElTokenTransfersByTxUid(ctx context.Context, txUid uint64) ([]*dbtypes.ElTokenTransfer, error) {
 	transfers := []*dbtypes.ElTokenTransfer{}
-	err := ReaderDb.SelectContext(ctx, &transfers, "SELECT block_uid, tx_hash, tx_pos, tx_idx, token_id, token_type, token_index, from_id, to_id, amount, amount_raw FROM el_token_transfers WHERE block_uid = $1 ORDER BY tx_pos ASC, tx_idx ASC", blockUid)
-	if err != nil {
-		return nil, err
-	}
-	return transfers, nil
-}
-
-func GetElTokenTransfersByBlockUidAndTxHash(ctx context.Context, blockUid uint64, txHash []byte) ([]*dbtypes.ElTokenTransfer, error) {
-	transfers := []*dbtypes.ElTokenTransfer{}
-	err := ReaderDb.SelectContext(ctx, &transfers, "SELECT block_uid, tx_hash, tx_pos, tx_idx, token_id, token_type, token_index, from_id, to_id, amount, amount_raw FROM el_token_transfers WHERE block_uid = $1 AND tx_hash = $2 ORDER BY tx_idx DESC", blockUid, txHash)
+	err := ReaderDb.SelectContext(ctx, &transfers, "SELECT tx_uid, tx_idx, token_id, token_type, token_index, from_id, to_id, amount, amount_raw FROM el_token_transfers WHERE tx_uid = $1 ORDER BY tx_idx DESC", txUid)
 	if err != nil {
 		return nil, err
 	}
@@ -123,12 +103,12 @@ func GetElTokenTransfersByTokenID(ctx context.Context, tokenID uint64, offset ui
 	// NULLS LAST matches the composite index definition to enable index scans.
 	fmt.Fprint(&sql, `
 		SELECT
-			block_uid, tx_hash, tx_pos, tx_idx, token_id, token_type, token_index,
+			tx_uid, tx_idx, token_id, token_type, token_index,
 			from_id, to_id, amount, amount_raw,
 			COUNT(*) OVER() AS total_count
 		FROM el_token_transfers
 		WHERE token_id = $1
-		ORDER BY block_uid DESC NULLS LAST, tx_pos DESC, tx_idx DESC
+		ORDER BY tx_uid DESC NULLS LAST, tx_idx DESC
 		LIMIT $2`)
 	args = append(args, limit)
 
@@ -178,12 +158,12 @@ func GetElTokenTransfersByAccountID(ctx context.Context, accountID uint64, isFro
 	// NULLS LAST matches the composite index definition to enable index scans.
 	fmt.Fprintf(&sql, `
 		SELECT
-			block_uid, tx_hash, tx_pos, tx_idx, token_id, token_type, token_index,
+			tx_uid, tx_idx, token_id, token_type, token_index,
 			from_id, to_id, amount, amount_raw,
 			COUNT(*) OVER() AS total_count
 		FROM el_token_transfers
 		WHERE %s = $1
-		ORDER BY block_uid DESC NULLS LAST, tx_pos DESC, tx_idx DESC
+		ORDER BY tx_uid DESC NULLS LAST, tx_idx DESC
 		LIMIT $2`, column)
 	args = append(args, limit)
 
@@ -226,7 +206,7 @@ func GetElTokenTransfersFiltered(ctx context.Context, offset uint64, limit uint3
 
 	fmt.Fprint(&sql, `
 	WITH cte AS (
-		SELECT block_uid, tx_hash, tx_pos, tx_idx, token_id, token_type, token_index, from_id, to_id, amount, amount_raw
+		SELECT tx_uid, tx_idx, token_id, token_type, token_index, from_id, to_id, amount, amount_raw
 		FROM el_token_transfers
 	`)
 
@@ -262,9 +242,7 @@ func GetElTokenTransfersFiltered(ctx context.Context, offset uint64, limit uint3
 	args = append(args, limit)
 	fmt.Fprintf(&sql, `
 	SELECT
-		count(*) AS block_uid,
-		null AS tx_hash,
-		0 AS tx_pos,
+		count(*) AS tx_uid,
 		0 AS tx_idx,
 		0 AS token_id,
 		0 AS token_type,
@@ -276,7 +254,7 @@ func GetElTokenTransfersFiltered(ctx context.Context, offset uint64, limit uint3
 	FROM cte
 	UNION ALL SELECT * FROM (
 	SELECT * FROM cte
-	ORDER BY block_uid DESC NULLS LAST, tx_pos DESC, tx_idx DESC
+	ORDER BY tx_uid DESC NULLS LAST, tx_idx DESC
 	LIMIT $%v`, len(args))
 
 	if offset > 0 {
@@ -296,7 +274,7 @@ func GetElTokenTransfersFiltered(ctx context.Context, offset uint64, limit uint3
 		return []*dbtypes.ElTokenTransfer{}, 0, nil
 	}
 
-	count := transfers[0].BlockUid
+	count := transfers[0].TxUid
 	return transfers[1:], count, nil
 }
 
@@ -305,7 +283,7 @@ func GetElTokenTransfersFiltered(ctx context.Context, offset uint64, limit uint3
 const MaxAccountTokenTransferCount = 100000
 
 // GetElTokenTransfersByAccountIDCombined returns all token transfers where the account is either sender or receiver.
-// Results are sorted by block_uid DESC, tx_pos DESC, tx_idx DESC.
+// Results are sorted by tx_uid DESC, tx_idx DESC.
 // tokenTypes filters by token type (empty = all types).
 // Returns transfers, total count (capped at MaxAccountTokenTransferCount), whether count is capped, and error.
 func GetElTokenTransfersByAccountIDCombined(ctx context.Context, accountID uint64, tokenTypes []uint8, offset uint64, limit uint32) ([]*dbtypes.ElTokenTransfer, uint64, bool, error) {
@@ -335,22 +313,22 @@ func GetElTokenTransfersByAccountIDCombined(ctx context.Context, accountID uint6
 	innerLimitIdx := len(args)
 
 	fmt.Fprintf(&sql, `
-		SELECT block_uid, tx_hash, tx_pos, tx_idx, token_id, token_type, token_index,
+		SELECT tx_uid, tx_idx, token_id, token_type, token_index,
 			from_id, to_id, amount, amount_raw
 		FROM (
-			SELECT * FROM (SELECT block_uid, tx_hash, tx_pos, tx_idx, token_id, token_type, token_index,
+			SELECT * FROM (SELECT tx_uid, tx_idx, token_id, token_type, token_index,
 				from_id, to_id, amount, amount_raw
 			FROM el_token_transfers WHERE from_id = $1%s
-			ORDER BY block_uid DESC NULLS LAST
+			ORDER BY tx_uid DESC NULLS LAST
 			LIMIT $%d) AS a
 			UNION ALL
-			SELECT * FROM (SELECT block_uid, tx_hash, tx_pos, tx_idx, token_id, token_type, token_index,
+			SELECT * FROM (SELECT tx_uid, tx_idx, token_id, token_type, token_index,
 				from_id, to_id, amount, amount_raw
 			FROM el_token_transfers WHERE to_id = $2 AND from_id != $3%s
-			ORDER BY block_uid DESC NULLS LAST
+			ORDER BY tx_uid DESC NULLS LAST
 			LIMIT $%d) AS b
 		) combined
-		ORDER BY block_uid DESC, tx_pos DESC, tx_idx DESC
+		ORDER BY tx_uid DESC, tx_idx DESC
 		LIMIT $%d`, tokenTypeFilter, innerLimitIdx, tokenTypeFilter, innerLimitIdx, len(args)+1)
 	args = append(args, limit)
 
@@ -367,9 +345,6 @@ func GetElTokenTransfersByAccountIDCombined(ctx context.Context, accountID uint6
 	}
 
 	// Count using separate index-only scans per direction, capped at MaxAccountTokenTransferCount.
-	// Counts from_id and to_id separately (without from_id != exclusion) for index-only scan
-	// performance. May slightly overcount self-referencing transfers, which is acceptable
-	// since the count is already an approximation (capped).
 	countArgs := []any{accountID}
 	countTokenTypeFilter := ""
 	if len(tokenTypes) > 0 {
@@ -409,18 +384,13 @@ func GetElTokenTransfersByAccountIDCombined(ctx context.Context, accountID uint6
 	return transfers, totalCount, moreAvailable, nil
 }
 
-func DeleteElTokenTransfer(ctx context.Context, dbTx *sqlx.Tx, blockUid uint64, txHash []byte, txIdx uint32) error {
-	_, err := dbTx.ExecContext(ctx, "DELETE FROM el_token_transfers WHERE block_uid = $1 AND tx_hash = $2 AND tx_idx = $3", blockUid, txHash, txIdx)
+func DeleteElTokenTransfer(ctx context.Context, dbTx *sqlx.Tx, txUid uint64, txIdx uint32) error {
+	_, err := dbTx.ExecContext(ctx, "DELETE FROM el_token_transfers WHERE tx_uid = $1 AND tx_idx = $2", txUid, txIdx)
 	return err
 }
 
-func DeleteElTokenTransfersByBlockUid(ctx context.Context, dbTx *sqlx.Tx, blockUid uint64) error {
-	_, err := dbTx.ExecContext(ctx, "DELETE FROM el_token_transfers WHERE block_uid = $1", blockUid)
-	return err
-}
-
-func DeleteElTokenTransfersByTxHash(ctx context.Context, dbTx *sqlx.Tx, txHash []byte) error {
-	_, err := dbTx.ExecContext(ctx, "DELETE FROM el_token_transfers WHERE tx_hash = $1", txHash)
+func DeleteElTokenTransfersByTxUid(ctx context.Context, dbTx *sqlx.Tx, txUid uint64) error {
+	_, err := dbTx.ExecContext(ctx, "DELETE FROM el_token_transfers WHERE tx_uid = $1", txUid)
 	return err
 }
 

--- a/db/el_transactions.go
+++ b/db/el_transactions.go
@@ -10,7 +10,7 @@ import (
 )
 
 // elTransactionColumns is the column list for el_transactions queries.
-const elTransactionColumns = "tx_uid, block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw, method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number, tx_type, tx_index, eff_gas_price"
+const elTransactionColumns = "tx_uid, block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw, method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number, tx_type, eff_gas_price"
 
 func InsertElTransactions(ctx context.Context, dbTx *sqlx.Tx, txs []*dbtypes.ElTransaction) error {
 	if len(txs) == 0 {
@@ -23,11 +23,11 @@ func InsertElTransactions(ctx context.Context, dbTx *sqlx.Tx, txs []*dbtypes.ElT
 			dbtypes.DBEnginePgsql:  "INSERT INTO el_transactions ",
 			dbtypes.DBEngineSqlite: "INSERT OR REPLACE INTO el_transactions ",
 		}),
-		"(tx_uid, block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw, method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number, tx_type, tx_index, eff_gas_price)",
+		"(tx_uid, block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw, method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number, tx_type, eff_gas_price)",
 		" VALUES ",
 	)
 	argIdx := 0
-	fieldCount := 19
+	fieldCount := 18
 
 	args := make([]any, len(txs)*fieldCount)
 	for i, tx := range txs {
@@ -60,12 +60,11 @@ func InsertElTransactions(ctx context.Context, dbTx *sqlx.Tx, txs []*dbtypes.ElT
 		args[argIdx+14] = tx.BlobCount
 		args[argIdx+15] = tx.BlockNumber
 		args[argIdx+16] = tx.TxType
-		args[argIdx+17] = tx.TxIndex
-		args[argIdx+18] = tx.EffGasPrice
+		args[argIdx+17] = tx.EffGasPrice
 		argIdx += fieldCount
 	}
 	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
-		dbtypes.DBEnginePgsql:  " ON CONFLICT (block_uid, tx_hash) DO UPDATE SET tx_uid = excluded.tx_uid, from_id = excluded.from_id, to_id = excluded.to_id, nonce = excluded.nonce, reverted = excluded.reverted, amount = excluded.amount, amount_raw = excluded.amount_raw, method_id = excluded.method_id, gas_limit = excluded.gas_limit, gas_used = excluded.gas_used, gas_price = excluded.gas_price, tip_price = excluded.tip_price, blob_count = excluded.blob_count, block_number = excluded.block_number, tx_type = excluded.tx_type, tx_index = excluded.tx_index, eff_gas_price = excluded.eff_gas_price",
+		dbtypes.DBEnginePgsql:  " ON CONFLICT (block_uid, tx_hash) DO UPDATE SET tx_uid = excluded.tx_uid, from_id = excluded.from_id, to_id = excluded.to_id, nonce = excluded.nonce, reverted = excluded.reverted, amount = excluded.amount, amount_raw = excluded.amount_raw, method_id = excluded.method_id, gas_limit = excluded.gas_limit, gas_used = excluded.gas_used, gas_price = excluded.gas_price, tip_price = excluded.tip_price, blob_count = excluded.blob_count, block_number = excluded.block_number, tx_type = excluded.tx_type, eff_gas_price = excluded.eff_gas_price",
 		dbtypes.DBEngineSqlite: "",
 	}))
 
@@ -266,7 +265,6 @@ func GetElTransactionsFiltered(ctx context.Context, offset uint64, limit uint32,
 		0 AS blob_count,
 		0 AS block_number,
 		0 AS tx_type,
-		0 AS tx_index,
 		0 AS eff_gas_price
 	FROM cte
 	UNION ALL SELECT * FROM (
@@ -300,7 +298,7 @@ func GetElTransactionsFiltered(ctx context.Context, offset uint64, limit uint32,
 const MaxAccountTransactionCount = 100000
 
 // GetElTransactionsByAccountIDCombined fetches transactions where the account is either
-// sender (from_id) or receiver (to_id). Results are sorted by block_uid DESC, tx_index DESC.
+// sender (from_id) or receiver (to_id). Results are sorted by tx_uid DESC.
 // Returns transactions, total count (capped at MaxAccountTransactionCount), whether count is capped, and error.
 func GetElTransactionsByAccountIDCombined(ctx context.Context, accountID uint64, offset uint64, limit uint32) ([]*dbtypes.ElTransaction, uint64, bool, error) {
 	// Use UNION ALL instead of OR for better index usage.
@@ -326,7 +324,7 @@ func GetElTransactionsByAccountIDCombined(ctx context.Context, accountID uint64,
 			ORDER BY block_uid DESC NULLS LAST
 			LIMIT $4) AS b
 		) combined
-		ORDER BY block_uid DESC, tx_index DESC
+		ORDER BY tx_uid DESC
 		LIMIT $5`, elTransactionColumns, elTransactionColumns, elTransactionColumns)
 	args = append(args, limit)
 

--- a/db/el_transactions.go
+++ b/db/el_transactions.go
@@ -9,6 +9,9 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+// elTransactionColumns is the column list for el_transactions queries.
+const elTransactionColumns = "tx_uid, block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw, method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number, tx_type, tx_index, eff_gas_price"
+
 func InsertElTransactions(ctx context.Context, dbTx *sqlx.Tx, txs []*dbtypes.ElTransaction) error {
 	if len(txs) == 0 {
 		return nil
@@ -20,11 +23,11 @@ func InsertElTransactions(ctx context.Context, dbTx *sqlx.Tx, txs []*dbtypes.ElT
 			dbtypes.DBEnginePgsql:  "INSERT INTO el_transactions ",
 			dbtypes.DBEngineSqlite: "INSERT OR REPLACE INTO el_transactions ",
 		}),
-		"(block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw, method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number, tx_type, tx_index, eff_gas_price)",
+		"(tx_uid, block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw, method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number, tx_type, tx_index, eff_gas_price)",
 		" VALUES ",
 	)
 	argIdx := 0
-	fieldCount := 18
+	fieldCount := 19
 
 	args := make([]any, len(txs)*fieldCount)
 	for i, tx := range txs {
@@ -40,28 +43,29 @@ func InsertElTransactions(ctx context.Context, dbTx *sqlx.Tx, txs []*dbtypes.ElT
 		}
 		fmt.Fprint(&sql, ")")
 
-		args[argIdx+0] = tx.BlockUid
-		args[argIdx+1] = tx.TxHash
-		args[argIdx+2] = tx.FromID
-		args[argIdx+3] = tx.ToID
-		args[argIdx+4] = tx.Nonce
-		args[argIdx+5] = tx.Reverted
-		args[argIdx+6] = tx.Amount
-		args[argIdx+7] = tx.AmountRaw
-		args[argIdx+8] = tx.MethodID
-		args[argIdx+9] = tx.GasLimit
-		args[argIdx+10] = tx.GasUsed
-		args[argIdx+11] = tx.GasPrice
-		args[argIdx+12] = tx.TipPrice
-		args[argIdx+13] = tx.BlobCount
-		args[argIdx+14] = tx.BlockNumber
-		args[argIdx+15] = tx.TxType
-		args[argIdx+16] = tx.TxIndex
-		args[argIdx+17] = tx.EffGasPrice
+		args[argIdx+0] = tx.TxUid
+		args[argIdx+1] = tx.BlockUid
+		args[argIdx+2] = tx.TxHash
+		args[argIdx+3] = tx.FromID
+		args[argIdx+4] = tx.ToID
+		args[argIdx+5] = tx.Nonce
+		args[argIdx+6] = tx.Reverted
+		args[argIdx+7] = tx.Amount
+		args[argIdx+8] = tx.AmountRaw
+		args[argIdx+9] = tx.MethodID
+		args[argIdx+10] = tx.GasLimit
+		args[argIdx+11] = tx.GasUsed
+		args[argIdx+12] = tx.GasPrice
+		args[argIdx+13] = tx.TipPrice
+		args[argIdx+14] = tx.BlobCount
+		args[argIdx+15] = tx.BlockNumber
+		args[argIdx+16] = tx.TxType
+		args[argIdx+17] = tx.TxIndex
+		args[argIdx+18] = tx.EffGasPrice
 		argIdx += fieldCount
 	}
 	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
-		dbtypes.DBEnginePgsql:  " ON CONFLICT (block_uid, tx_hash) DO UPDATE SET from_id = excluded.from_id, to_id = excluded.to_id, nonce = excluded.nonce, reverted = excluded.reverted, amount = excluded.amount, amount_raw = excluded.amount_raw, method_id = excluded.method_id, gas_limit = excluded.gas_limit, gas_used = excluded.gas_used, gas_price = excluded.gas_price, tip_price = excluded.tip_price, blob_count = excluded.blob_count, block_number = excluded.block_number, tx_type = excluded.tx_type, tx_index = excluded.tx_index, eff_gas_price = excluded.eff_gas_price",
+		dbtypes.DBEnginePgsql:  " ON CONFLICT (block_uid, tx_hash) DO UPDATE SET tx_uid = excluded.tx_uid, from_id = excluded.from_id, to_id = excluded.to_id, nonce = excluded.nonce, reverted = excluded.reverted, amount = excluded.amount, amount_raw = excluded.amount_raw, method_id = excluded.method_id, gas_limit = excluded.gas_limit, gas_used = excluded.gas_used, gas_price = excluded.gas_price, tip_price = excluded.tip_price, blob_count = excluded.blob_count, block_number = excluded.block_number, tx_type = excluded.tx_type, tx_index = excluded.tx_index, eff_gas_price = excluded.eff_gas_price",
 		dbtypes.DBEngineSqlite: "",
 	}))
 
@@ -74,7 +78,7 @@ func InsertElTransactions(ctx context.Context, dbTx *sqlx.Tx, txs []*dbtypes.ElT
 
 func GetElTransaction(ctx context.Context, blockUid uint64, txHash []byte) (*dbtypes.ElTransaction, error) {
 	tx := &dbtypes.ElTransaction{}
-	err := ReaderDb.GetContext(ctx, tx, "SELECT block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw, method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number, tx_type, tx_index, eff_gas_price FROM el_transactions WHERE block_uid = $1 AND tx_hash = $2", blockUid, txHash)
+	err := ReaderDb.GetContext(ctx, tx, "SELECT "+elTransactionColumns+" FROM el_transactions WHERE block_uid = $1 AND tx_hash = $2", blockUid, txHash)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +87,7 @@ func GetElTransaction(ctx context.Context, blockUid uint64, txHash []byte) (*dbt
 
 func GetElTransactionsByHash(ctx context.Context, txHash []byte) ([]*dbtypes.ElTransaction, error) {
 	txs := []*dbtypes.ElTransaction{}
-	err := ReaderDb.SelectContext(ctx, &txs, "SELECT block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw, method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number, tx_type, tx_index, eff_gas_price FROM el_transactions WHERE tx_hash = $1 ORDER BY block_uid DESC", txHash)
+	err := ReaderDb.SelectContext(ctx, &txs, "SELECT "+elTransactionColumns+" FROM el_transactions WHERE tx_hash = $1 ORDER BY block_uid DESC", txHash)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +105,7 @@ func GetElTransactionsByHashes(ctx context.Context, txHashes [][]byte) ([]*dbtyp
 	var sql strings.Builder
 	args := make([]any, len(txHashes))
 
-	fmt.Fprint(&sql, "SELECT block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw, method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number, tx_type, tx_index, eff_gas_price FROM el_transactions WHERE tx_hash IN (")
+	fmt.Fprint(&sql, "SELECT "+elTransactionColumns+" FROM el_transactions WHERE tx_hash IN (")
 	for i, h := range txHashes {
 		args[i] = h
 	}
@@ -115,9 +119,34 @@ func GetElTransactionsByHashes(ctx context.Context, txHashes [][]byte) ([]*dbtyp
 	return txs, nil
 }
 
+// GetElTransactionsByTxUids returns all transaction records matching the given
+// tx_uids. Used by handlers to resolve tx_hash and other fields from dependent
+// table results that only store tx_uid.
+func GetElTransactionsByTxUids(ctx context.Context, txUids []uint64) ([]*dbtypes.ElTransaction, error) {
+	if len(txUids) == 0 {
+		return []*dbtypes.ElTransaction{}, nil
+	}
+
+	var sql strings.Builder
+	args := make([]any, len(txUids))
+
+	fmt.Fprint(&sql, "SELECT "+elTransactionColumns+" FROM el_transactions WHERE tx_uid IN (")
+	for i, uid := range txUids {
+		args[i] = uid
+	}
+	appendDollarPlaceholders(&sql, 1, len(txUids), ", ")
+	fmt.Fprint(&sql, ")")
+
+	txs := []*dbtypes.ElTransaction{}
+	if err := ReaderDb.SelectContext(ctx, &txs, sql.String(), args...); err != nil {
+		return nil, err
+	}
+	return txs, nil
+}
+
 func GetElTransactionsByBlockUid(ctx context.Context, blockUid uint64) ([]*dbtypes.ElTransaction, error) {
 	txs := []*dbtypes.ElTransaction{}
-	err := ReaderDb.SelectContext(ctx, &txs, "SELECT block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw, method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number, tx_type, tx_index, eff_gas_price FROM el_transactions WHERE block_uid = $1", blockUid)
+	err := ReaderDb.SelectContext(ctx, &txs, "SELECT "+elTransactionColumns+" FROM el_transactions WHERE block_uid = $1", blockUid)
 	if err != nil {
 		return nil, err
 	}
@@ -137,14 +166,12 @@ func GetElTransactionsByAccountID(ctx context.Context, accountID uint64, isFrom 
 	// NULLS LAST matches the composite index definition to enable index scans.
 	fmt.Fprintf(&sql, `
 		SELECT
-			block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw,
-			method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number,
-			tx_type, tx_index, eff_gas_price,
+			%s,
 			COUNT(*) OVER() AS total_count
 		FROM el_transactions
 		WHERE %s = $1
 		ORDER BY block_uid DESC NULLS LAST, tx_hash DESC
-		LIMIT $2`, column)
+		LIMIT $2`, elTransactionColumns, column)
 	args = append(args, limit)
 
 	if offset > 0 {
@@ -184,11 +211,11 @@ func GetElTransactionsFiltered(ctx context.Context, offset uint64, limit uint32,
 	var sql strings.Builder
 	args := []any{}
 
-	fmt.Fprint(&sql, `
+	fmt.Fprintf(&sql, `
 	WITH cte AS (
-		SELECT block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw, method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number, tx_type, tx_index, eff_gas_price
+		SELECT %s
 		FROM el_transactions
-	`)
+	`, elTransactionColumns)
 
 	filterOp := "WHERE"
 	if filter.FromID > 0 {
@@ -222,7 +249,8 @@ func GetElTransactionsFiltered(ctx context.Context, offset uint64, limit uint32,
 	args = append(args, limit)
 	fmt.Fprintf(&sql, `
 	SELECT
-		count(*) AS block_uid,
+		count(*) AS tx_uid,
+		0 AS block_uid,
 		null AS tx_hash,
 		0 AS from_id,
 		0 AS to_id,
@@ -263,7 +291,7 @@ func GetElTransactionsFiltered(ctx context.Context, offset uint64, limit uint32,
 		return []*dbtypes.ElTransaction{}, 0, nil
 	}
 
-	count := txs[0].BlockUid
+	count := txs[0].TxUid
 	return txs[1:], count, nil
 }
 
@@ -285,27 +313,21 @@ func GetElTransactionsByAccountIDCombined(ctx context.Context, accountID uint64,
 	innerLimit := offset + uint64(limit)
 	args := []any{accountID, accountID, accountID, innerLimit}
 
-	fmt.Fprint(&sql, `
-		SELECT block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw,
-			method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number,
-			tx_type, tx_index, eff_gas_price
+	fmt.Fprintf(&sql, `
+		SELECT %s
 		FROM (
-			SELECT * FROM (SELECT block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw,
-				method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number,
-				tx_type, tx_index, eff_gas_price
+			SELECT * FROM (SELECT %s
 			FROM el_transactions WHERE from_id = $1
 			ORDER BY block_uid DESC NULLS LAST
 			LIMIT $4) AS a
 			UNION ALL
-			SELECT * FROM (SELECT block_uid, tx_hash, from_id, to_id, nonce, reverted, amount, amount_raw,
-				method_id, gas_limit, gas_used, gas_price, tip_price, blob_count, block_number,
-				tx_type, tx_index, eff_gas_price
+			SELECT * FROM (SELECT %s
 			FROM el_transactions WHERE to_id = $2 AND from_id != $3
 			ORDER BY block_uid DESC NULLS LAST
 			LIMIT $4) AS b
 		) combined
 		ORDER BY block_uid DESC, tx_index DESC
-		LIMIT $5`)
+		LIMIT $5`, elTransactionColumns, elTransactionColumns, elTransactionColumns)
 	args = append(args, limit)
 
 	if offset > 0 {

--- a/db/el_transactions_internal.go
+++ b/db/el_transactions_internal.go
@@ -21,12 +21,12 @@ func InsertElTransactionsInternal(ctx context.Context, dbTx *sqlx.Tx, entries []
 			dbtypes.DBEnginePgsql:  "INSERT INTO el_transactions_internal ",
 			dbtypes.DBEngineSqlite: "INSERT OR REPLACE INTO el_transactions_internal ",
 		}),
-		"(block_uid, tx_hash, tx_callidx, call_type, from_id, to_id, value, value_raw)",
+		"(tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw)",
 		" VALUES ",
 	)
 
 	argIdx := 0
-	fieldCount := 8
+	fieldCount := 7
 	args := make([]any, len(entries)*fieldCount)
 
 	for i, entry := range entries {
@@ -42,19 +42,18 @@ func InsertElTransactionsInternal(ctx context.Context, dbTx *sqlx.Tx, entries []
 		}
 		fmt.Fprint(&sql, ")")
 
-		args[argIdx+0] = entry.BlockUid
-		args[argIdx+1] = entry.TxHash
-		args[argIdx+2] = entry.TxCallIdx
-		args[argIdx+3] = entry.CallType
-		args[argIdx+4] = entry.FromID
-		args[argIdx+5] = entry.ToID
-		args[argIdx+6] = entry.Value
-		args[argIdx+7] = entry.ValueRaw
+		args[argIdx+0] = entry.TxUid
+		args[argIdx+1] = entry.TxCallIdx
+		args[argIdx+2] = entry.CallType
+		args[argIdx+3] = entry.FromID
+		args[argIdx+4] = entry.ToID
+		args[argIdx+5] = entry.Value
+		args[argIdx+6] = entry.ValueRaw
 		argIdx += fieldCount
 	}
 
 	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
-		dbtypes.DBEnginePgsql: " ON CONFLICT (block_uid, tx_hash, tx_callidx) DO UPDATE SET" +
+		dbtypes.DBEnginePgsql: " ON CONFLICT (tx_uid, tx_callidx) DO UPDATE SET" +
 			" call_type = excluded.call_type," +
 			" from_id = excluded.from_id," +
 			" to_id = excluded.to_id," +
@@ -86,9 +85,9 @@ func HasElTransactionsInternalByAccount(ctx context.Context, accountID uint64) (
 const MaxAccountInternalTxCount = 100000
 
 // GetElTransactionsInternalByAccount returns internal transactions
-// involving the given account (as sender or receiver), ordered by block_uid DESC.
+// involving the given account (as sender or receiver), ordered by tx_uid DESC.
 // Uses UNION ALL instead of OR to enable index scans on the composite indexes
-// (from_id, block_uid DESC) and (to_id, block_uid DESC).
+// (from_id, tx_uid DESC) and (to_id, tx_uid DESC).
 // NULLS LAST is required to match the index definition and enable index scans.
 func GetElTransactionsInternalByAccount(
 	ctx context.Context,
@@ -102,19 +101,19 @@ func GetElTransactionsInternalByAccount(
 	args := []any{accountID, accountID, accountID, innerLimit}
 
 	fmt.Fprint(&sql, `
-		SELECT block_uid, tx_hash, tx_callidx, call_type, from_id, to_id, value, value_raw
+		SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw
 		FROM (
-			(SELECT block_uid, tx_hash, tx_callidx, call_type, from_id, to_id, value, value_raw
+			(SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw
 			FROM el_transactions_internal WHERE from_id = $1
-			ORDER BY block_uid DESC NULLS LAST
+			ORDER BY tx_uid DESC NULLS LAST
 			LIMIT $4)
 			UNION ALL
-			(SELECT block_uid, tx_hash, tx_callidx, call_type, from_id, to_id, value, value_raw
+			(SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw
 			FROM el_transactions_internal WHERE to_id = $2 AND from_id != $3
-			ORDER BY block_uid DESC NULLS LAST
+			ORDER BY tx_uid DESC NULLS LAST
 			LIMIT $4)
 		) combined
-		ORDER BY block_uid DESC, tx_hash ASC, tx_callidx ASC
+		ORDER BY tx_uid DESC, tx_callidx ASC
 		LIMIT $5`)
 	args = append(args, limit)
 
@@ -130,9 +129,6 @@ func GetElTransactionsInternalByAccount(
 	}
 
 	// Count query: separate index-only scans per direction, capped at MaxAccountInternalTxCount.
-	// Counts from_id and to_id separately (without from_id != exclusion) for index-only scan
-	// performance. May slightly overcount self-referencing internal calls, which is acceptable
-	// since the count is already an approximation (capped).
 	countSQL := `
 		SELECT
 			(SELECT COUNT(*) FROM (SELECT 1 FROM el_transactions_internal WHERE from_id = $1 LIMIT $2) a) +
@@ -150,13 +146,13 @@ func GetElTransactionsInternalByAccount(
 	return entries, totalCount, nil
 }
 
-// GetElTransactionsInternalCountByTxHash returns the number of internal
-// transactions for a given transaction hash. Uses an index-only scan.
-func GetElTransactionsInternalCountByTxHash(ctx context.Context, txHash []byte) (uint64, error) {
+// GetElTransactionsInternalCountByTxUid returns the number of internal
+// transactions for a given transaction UID.
+func GetElTransactionsInternalCountByTxUid(ctx context.Context, txUid uint64) (uint64, error) {
 	var count uint64
 	err := ReaderDb.GetContext(ctx, &count,
-		"SELECT COUNT(*) FROM el_transactions_internal WHERE tx_hash = $1",
-		txHash,
+		"SELECT COUNT(*) FROM el_transactions_internal WHERE tx_uid = $1",
+		txUid,
 	)
 	if err != nil {
 		return 0, err
@@ -164,14 +160,14 @@ func GetElTransactionsInternalCountByTxHash(ctx context.Context, txHash []byte) 
 	return count, nil
 }
 
-// GetElTransactionsInternalByTxHash returns all internal transactions
-// for a given transaction hash.
-func GetElTransactionsInternalByTxHash(ctx context.Context, txHash []byte) ([]*dbtypes.ElTransactionInternal, error) {
+// GetElTransactionsInternalByTxUid returns all internal transactions
+// for a given transaction UID.
+func GetElTransactionsInternalByTxUid(ctx context.Context, txUid uint64) ([]*dbtypes.ElTransactionInternal, error) {
 	entries := []*dbtypes.ElTransactionInternal{}
 	err := ReaderDb.SelectContext(ctx, &entries,
-		"SELECT block_uid, tx_hash, tx_callidx, call_type, from_id, to_id, value, value_raw"+
-			" FROM el_transactions_internal WHERE tx_hash = $1 ORDER BY tx_callidx ASC",
-		txHash,
+		"SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw"+
+			" FROM el_transactions_internal WHERE tx_uid = $1 ORDER BY tx_callidx ASC",
+		txUid,
 	)
 	if err != nil {
 		return nil, err

--- a/db/el_transactions_internal.go
+++ b/db/el_transactions_internal.go
@@ -103,15 +103,15 @@ func GetElTransactionsInternalByAccount(
 	fmt.Fprint(&sql, `
 		SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw
 		FROM (
-			(SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw
+			SELECT * FROM (SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw
 			FROM el_transactions_internal WHERE from_id = $1
 			ORDER BY tx_uid DESC NULLS LAST
-			LIMIT $4)
+			LIMIT $4) AS a
 			UNION ALL
-			(SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw
+			SELECT * FROM (SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw
 			FROM el_transactions_internal WHERE to_id = $2 AND from_id != $3
 			ORDER BY tx_uid DESC NULLS LAST
-			LIMIT $4)
+			LIMIT $4) AS b
 		) combined
 		ORDER BY tx_uid DESC, tx_callidx ASC
 		LIMIT $5`)

--- a/db/schema/pgsql/20260417000000_tx-uid.sql
+++ b/db/schema/pgsql/20260417000000_tx-uid.sql
@@ -150,6 +150,9 @@ CREATE INDEX IF NOT EXISTS "el_internal_tx_to_only_idx"
     ON public."el_transactions_internal"
     ("to_id" ASC NULLS FIRST);
 
+-- Step 5: Drop tx_index from el_transactions (redundant with tx_uid & 0xFFFF) ---
+ALTER TABLE public."el_transactions" DROP COLUMN IF EXISTS tx_index;
+
 -- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin

--- a/db/schema/pgsql/20260417000000_tx-uid.sql
+++ b/db/schema/pgsql/20260417000000_tx-uid.sql
@@ -27,7 +27,7 @@ CREATE TABLE public."el_event_index_new" (
     event_index INT NOT NULL,
     source_id BIGINT NOT NULL DEFAULT 0,
     topic1 bytea,
-    CONSTRAINT el_event_index_pkey PRIMARY KEY (tx_uid, event_index)
+    PRIMARY KEY (tx_uid, event_index)
 );
 
 INSERT INTO public."el_event_index_new" (tx_uid, event_index, source_id, topic1)
@@ -71,7 +71,7 @@ CREATE TABLE public."el_token_transfers_new" (
     to_id BIGINT NOT NULL,
     amount DOUBLE PRECISION NOT NULL DEFAULT 0,
     amount_raw bytea NOT NULL,
-    CONSTRAINT el_token_transfers_pkey PRIMARY KEY (tx_uid, tx_idx)
+    PRIMARY KEY (tx_uid, tx_idx)
 );
 
 INSERT INTO public."el_token_transfers_new"
@@ -120,7 +120,7 @@ CREATE TABLE public."el_transactions_internal_new" (
     to_id BIGINT NOT NULL DEFAULT 0,
     value DOUBLE PRECISION NOT NULL DEFAULT 0,
     value_raw bytea,
-    CONSTRAINT el_transactions_internal_pkey PRIMARY KEY (tx_uid, tx_callidx)
+    PRIMARY KEY (tx_uid, tx_callidx)
 );
 
 INSERT INTO public."el_transactions_internal_new"

--- a/db/schema/pgsql/20260417000000_tx-uid.sql
+++ b/db/schema/pgsql/20260417000000_tx-uid.sql
@@ -1,0 +1,157 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Introduce tx_uid = block_uid << 16 | tx_index as a compact unique transaction
+-- identifier.  Dependent tables (el_event_index, el_token_transfers,
+-- el_transactions_internal) switch from (block_uid, tx_hash) to tx_uid, saving
+-- 32 bytes per row (the 32-byte tx_hash) and 8 bytes (block_uid) while gaining
+-- a single 8-byte foreign reference.
+
+-- Step 1: Add tx_uid column to el_transactions ----------------------------------
+ALTER TABLE public."el_transactions"
+    ADD COLUMN IF NOT EXISTS tx_uid BIGINT NOT NULL DEFAULT 0;
+
+UPDATE public."el_transactions"
+    SET tx_uid = (block_uid << 16) | tx_index::bigint;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "el_transactions_tx_uid_idx"
+    ON public."el_transactions" ("tx_uid");
+
+-- Step 2: Recreate el_event_index with tx_uid -----------------------------------
+DROP INDEX IF EXISTS "el_event_index_source_idx";
+DROP INDEX IF EXISTS "el_event_index_topic1_idx";
+DROP INDEX IF EXISTS "el_event_index_tx_hash_idx";
+
+CREATE TABLE public."el_event_index_new" (
+    tx_uid BIGINT NOT NULL,
+    event_index INT NOT NULL,
+    source_id BIGINT NOT NULL DEFAULT 0,
+    topic1 bytea,
+    CONSTRAINT el_event_index_pkey PRIMARY KEY (tx_uid, event_index)
+);
+
+INSERT INTO public."el_event_index_new" (tx_uid, event_index, source_id, topic1)
+SELECT t.tx_uid, e.event_index, e.source_id, e.topic1
+FROM public."el_event_index" e
+JOIN public."el_transactions" t
+    ON e.block_uid = t.block_uid AND e.tx_hash = t.tx_hash;
+
+DROP TABLE public."el_event_index";
+ALTER TABLE public."el_event_index_new" RENAME TO "el_event_index";
+
+CREATE INDEX IF NOT EXISTS "el_event_index_source_idx"
+    ON public."el_event_index"
+    ("source_id" ASC NULLS FIRST, "tx_uid" DESC NULLS LAST);
+
+CREATE INDEX IF NOT EXISTS "el_event_index_topic1_idx"
+    ON public."el_event_index"
+    ("topic1" ASC NULLS FIRST, "tx_uid" DESC NULLS LAST);
+
+-- Step 3: Recreate el_token_transfers with tx_uid --------------------------------
+DROP INDEX IF EXISTS "el_token_transfers_block_uid_idx";
+DROP INDEX IF EXISTS "el_token_transfers_tx_hash_idx";
+DROP INDEX IF EXISTS "el_token_transfers_token_id_idx";
+DROP INDEX IF EXISTS "el_token_transfers_token_type_idx";
+DROP INDEX IF EXISTS "el_token_transfers_token_index_idx";
+DROP INDEX IF EXISTS "el_token_transfers_from_idx";
+DROP INDEX IF EXISTS "el_token_transfers_to_idx";
+DROP INDEX IF EXISTS "el_token_transfers_token_block_idx";
+DROP INDEX IF EXISTS "el_token_transfers_from_block_idx";
+DROP INDEX IF EXISTS "el_token_transfers_to_block_idx";
+DROP INDEX IF EXISTS "el_token_transfers_from_type_idx";
+DROP INDEX IF EXISTS "el_token_transfers_to_type_idx";
+
+CREATE TABLE public."el_token_transfers_new" (
+    tx_uid BIGINT NOT NULL,
+    tx_idx INT NOT NULL,
+    token_id BIGINT NOT NULL,
+    token_type SMALLINT NOT NULL DEFAULT 0,
+    token_index bytea NULL,
+    from_id BIGINT NOT NULL,
+    to_id BIGINT NOT NULL,
+    amount DOUBLE PRECISION NOT NULL DEFAULT 0,
+    amount_raw bytea NOT NULL,
+    CONSTRAINT el_token_transfers_pkey PRIMARY KEY (tx_uid, tx_idx)
+);
+
+INSERT INTO public."el_token_transfers_new"
+    (tx_uid, tx_idx, token_id, token_type, token_index, from_id, to_id, amount, amount_raw)
+SELECT t.tx_uid, tt.tx_idx, tt.token_id, tt.token_type, tt.token_index,
+       tt.from_id, tt.to_id, tt.amount, tt.amount_raw
+FROM public."el_token_transfers" tt
+JOIN public."el_transactions" t
+    ON tt.block_uid = t.block_uid AND tt.tx_hash = t.tx_hash;
+
+DROP TABLE public."el_token_transfers";
+ALTER TABLE public."el_token_transfers_new" RENAME TO "el_token_transfers";
+
+CREATE INDEX IF NOT EXISTS "el_token_transfers_token_uid_idx"
+    ON public."el_token_transfers"
+    ("token_id" ASC NULLS FIRST, "tx_uid" DESC NULLS LAST);
+
+CREATE INDEX IF NOT EXISTS "el_token_transfers_from_uid_idx"
+    ON public."el_token_transfers"
+    ("from_id" ASC NULLS FIRST, "tx_uid" DESC NULLS LAST);
+
+CREATE INDEX IF NOT EXISTS "el_token_transfers_to_uid_idx"
+    ON public."el_token_transfers"
+    ("to_id" ASC NULLS FIRST, "tx_uid" DESC NULLS LAST);
+
+CREATE INDEX IF NOT EXISTS "el_token_transfers_from_type_idx"
+    ON public."el_token_transfers"
+    ("from_id" ASC NULLS FIRST, "token_type" ASC NULLS FIRST);
+
+CREATE INDEX IF NOT EXISTS "el_token_transfers_to_type_idx"
+    ON public."el_token_transfers"
+    ("to_id" ASC NULLS FIRST, "token_type" ASC NULLS FIRST);
+
+-- Step 4: Recreate el_transactions_internal with tx_uid --------------------------
+DROP INDEX IF EXISTS "el_internal_tx_from_idx";
+DROP INDEX IF EXISTS "el_internal_tx_to_idx";
+DROP INDEX IF EXISTS "el_internal_tx_hash_idx";
+DROP INDEX IF EXISTS "el_internal_tx_from_only_idx";
+DROP INDEX IF EXISTS "el_internal_tx_to_only_idx";
+
+CREATE TABLE public."el_transactions_internal_new" (
+    tx_uid BIGINT NOT NULL,
+    tx_callidx INT NOT NULL,
+    call_type SMALLINT NOT NULL DEFAULT 0,
+    from_id BIGINT NOT NULL DEFAULT 0,
+    to_id BIGINT NOT NULL DEFAULT 0,
+    value DOUBLE PRECISION NOT NULL DEFAULT 0,
+    value_raw bytea,
+    CONSTRAINT el_transactions_internal_pkey PRIMARY KEY (tx_uid, tx_callidx)
+);
+
+INSERT INTO public."el_transactions_internal_new"
+    (tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw)
+SELECT t.tx_uid, ti.tx_callidx, ti.call_type, ti.from_id, ti.to_id,
+       ti.value, ti.value_raw
+FROM public."el_transactions_internal" ti
+JOIN public."el_transactions" t
+    ON ti.block_uid = t.block_uid AND ti.tx_hash = t.tx_hash;
+
+DROP TABLE public."el_transactions_internal";
+ALTER TABLE public."el_transactions_internal_new" RENAME TO "el_transactions_internal";
+
+CREATE INDEX IF NOT EXISTS "el_internal_tx_from_idx"
+    ON public."el_transactions_internal"
+    ("from_id" ASC NULLS FIRST, "tx_uid" DESC NULLS LAST);
+
+CREATE INDEX IF NOT EXISTS "el_internal_tx_to_idx"
+    ON public."el_transactions_internal"
+    ("to_id" ASC NULLS FIRST, "tx_uid" DESC NULLS LAST);
+
+CREATE INDEX IF NOT EXISTS "el_internal_tx_from_only_idx"
+    ON public."el_transactions_internal"
+    ("from_id" ASC NULLS FIRST);
+
+CREATE INDEX IF NOT EXISTS "el_internal_tx_to_only_idx"
+    ON public."el_transactions_internal"
+    ("to_id" ASC NULLS FIRST);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/db/schema/sqlite/20260417000000_tx-uid.sql
+++ b/db/schema/sqlite/20260417000000_tx-uid.sql
@@ -1,0 +1,131 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Introduce tx_uid = block_uid << 16 | tx_index as a compact unique transaction
+-- identifier.  Dependent tables switch from (block_uid, tx_hash) to tx_uid.
+
+-- Step 1: Add tx_uid column to el_transactions ----------------------------------
+ALTER TABLE "el_transactions" ADD COLUMN tx_uid INTEGER NOT NULL DEFAULT 0;
+UPDATE "el_transactions" SET tx_uid = (block_uid << 16) | tx_index;
+CREATE UNIQUE INDEX IF NOT EXISTS "el_transactions_tx_uid_idx"
+    ON "el_transactions" ("tx_uid");
+
+-- Step 2: Recreate el_event_index with tx_uid -----------------------------------
+DROP INDEX IF EXISTS "el_event_index_source_idx";
+DROP INDEX IF EXISTS "el_event_index_topic1_idx";
+DROP INDEX IF EXISTS "el_event_index_tx_hash_idx";
+
+CREATE TABLE "el_event_index_new" (
+    tx_uid INTEGER NOT NULL,
+    event_index INTEGER NOT NULL,
+    source_id INTEGER NOT NULL DEFAULT 0,
+    topic1 BLOB,
+    CONSTRAINT el_event_index_pkey PRIMARY KEY (tx_uid, event_index)
+);
+
+INSERT INTO "el_event_index_new" (tx_uid, event_index, source_id, topic1)
+SELECT t.tx_uid, e.event_index, e.source_id, e.topic1
+FROM "el_event_index" e
+JOIN "el_transactions" t
+    ON e.block_uid = t.block_uid AND e.tx_hash = t.tx_hash;
+
+DROP TABLE "el_event_index";
+ALTER TABLE "el_event_index_new" RENAME TO "el_event_index";
+
+CREATE INDEX IF NOT EXISTS "el_event_index_source_idx"
+    ON "el_event_index" ("source_id" ASC, "tx_uid" DESC);
+CREATE INDEX IF NOT EXISTS "el_event_index_topic1_idx"
+    ON "el_event_index" ("topic1" ASC, "tx_uid" DESC);
+
+-- Step 3: Recreate el_token_transfers with tx_uid --------------------------------
+DROP INDEX IF EXISTS "el_token_transfers_block_uid_idx";
+DROP INDEX IF EXISTS "el_token_transfers_tx_hash_idx";
+DROP INDEX IF EXISTS "el_token_transfers_token_id_idx";
+DROP INDEX IF EXISTS "el_token_transfers_token_type_idx";
+DROP INDEX IF EXISTS "el_token_transfers_token_index_idx";
+DROP INDEX IF EXISTS "el_token_transfers_from_idx";
+DROP INDEX IF EXISTS "el_token_transfers_to_idx";
+DROP INDEX IF EXISTS "el_token_transfers_token_block_idx";
+DROP INDEX IF EXISTS "el_token_transfers_from_block_idx";
+DROP INDEX IF EXISTS "el_token_transfers_to_block_idx";
+DROP INDEX IF EXISTS "el_token_transfers_from_type_idx";
+DROP INDEX IF EXISTS "el_token_transfers_to_type_idx";
+
+CREATE TABLE "el_token_transfers_new" (
+    tx_uid INTEGER NOT NULL,
+    tx_idx INTEGER NOT NULL,
+    token_id INTEGER NOT NULL,
+    token_type INTEGER NOT NULL DEFAULT 0,
+    token_index BLOB NULL,
+    from_id INTEGER NOT NULL,
+    to_id INTEGER NOT NULL,
+    amount REAL NOT NULL DEFAULT 0,
+    amount_raw BLOB NOT NULL,
+    CONSTRAINT el_token_transfers_pkey PRIMARY KEY (tx_uid, tx_idx)
+);
+
+INSERT INTO "el_token_transfers_new"
+    (tx_uid, tx_idx, token_id, token_type, token_index, from_id, to_id, amount, amount_raw)
+SELECT t.tx_uid, tt.tx_idx, tt.token_id, tt.token_type, tt.token_index,
+       tt.from_id, tt.to_id, tt.amount, tt.amount_raw
+FROM "el_token_transfers" tt
+JOIN "el_transactions" t
+    ON tt.block_uid = t.block_uid AND tt.tx_hash = t.tx_hash;
+
+DROP TABLE "el_token_transfers";
+ALTER TABLE "el_token_transfers_new" RENAME TO "el_token_transfers";
+
+CREATE INDEX IF NOT EXISTS "el_token_transfers_token_uid_idx"
+    ON "el_token_transfers" ("token_id" ASC, "tx_uid" DESC);
+CREATE INDEX IF NOT EXISTS "el_token_transfers_from_uid_idx"
+    ON "el_token_transfers" ("from_id" ASC, "tx_uid" DESC);
+CREATE INDEX IF NOT EXISTS "el_token_transfers_to_uid_idx"
+    ON "el_token_transfers" ("to_id" ASC, "tx_uid" DESC);
+CREATE INDEX IF NOT EXISTS "el_token_transfers_from_type_idx"
+    ON "el_token_transfers" ("from_id" ASC, "token_type" ASC);
+CREATE INDEX IF NOT EXISTS "el_token_transfers_to_type_idx"
+    ON "el_token_transfers" ("to_id" ASC, "token_type" ASC);
+
+-- Step 4: Recreate el_transactions_internal with tx_uid --------------------------
+DROP INDEX IF EXISTS "el_internal_tx_from_idx";
+DROP INDEX IF EXISTS "el_internal_tx_to_idx";
+DROP INDEX IF EXISTS "el_internal_tx_hash_idx";
+DROP INDEX IF EXISTS "el_internal_tx_from_only_idx";
+DROP INDEX IF EXISTS "el_internal_tx_to_only_idx";
+
+CREATE TABLE "el_transactions_internal_new" (
+    tx_uid INTEGER NOT NULL,
+    tx_callidx INTEGER NOT NULL,
+    call_type INTEGER NOT NULL DEFAULT 0,
+    from_id INTEGER NOT NULL DEFAULT 0,
+    to_id INTEGER NOT NULL DEFAULT 0,
+    value REAL NOT NULL DEFAULT 0,
+    value_raw BLOB,
+    CONSTRAINT el_transactions_internal_pkey PRIMARY KEY (tx_uid, tx_callidx)
+);
+
+INSERT INTO "el_transactions_internal_new"
+    (tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw)
+SELECT t.tx_uid, ti.tx_callidx, ti.call_type, ti.from_id, ti.to_id,
+       ti.value, ti.value_raw
+FROM "el_transactions_internal" ti
+JOIN "el_transactions" t
+    ON ti.block_uid = t.block_uid AND ti.tx_hash = t.tx_hash;
+
+DROP TABLE "el_transactions_internal";
+ALTER TABLE "el_transactions_internal_new" RENAME TO "el_transactions_internal";
+
+CREATE INDEX IF NOT EXISTS "el_internal_tx_from_idx"
+    ON "el_transactions_internal" ("from_id" ASC, "tx_uid" DESC);
+CREATE INDEX IF NOT EXISTS "el_internal_tx_to_idx"
+    ON "el_transactions_internal" ("to_id" ASC, "tx_uid" DESC);
+CREATE INDEX IF NOT EXISTS "el_internal_tx_from_only_idx"
+    ON "el_transactions_internal" ("from_id" ASC);
+CREATE INDEX IF NOT EXISTS "el_internal_tx_to_only_idx"
+    ON "el_transactions_internal" ("to_id" ASC);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/db/schema/sqlite/20260417000000_tx-uid.sql
+++ b/db/schema/sqlite/20260417000000_tx-uid.sql
@@ -124,6 +124,10 @@ CREATE INDEX IF NOT EXISTS "el_internal_tx_from_only_idx"
 CREATE INDEX IF NOT EXISTS "el_internal_tx_to_only_idx"
     ON "el_transactions_internal" ("to_id" ASC);
 
+-- Step 5: Drop tx_index from el_transactions (redundant with tx_uid & 0xFFFF) ---
+-- SQLite 3.35.0+ supports ALTER TABLE DROP COLUMN
+ALTER TABLE "el_transactions" DROP COLUMN tx_index;
+
 -- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin

--- a/dbtypes/dbtypes.go
+++ b/dbtypes/dbtypes.go
@@ -471,6 +471,7 @@ const (
 )
 
 type ElTransaction struct {
+	TxUid       uint64  `db:"tx_uid"` // block_uid << 16 | tx_index
 	BlockUid    uint64  `db:"block_uid"`
 	TxHash      []byte  `db:"tx_hash"`
 	FromID      uint64  `db:"from_id"`
@@ -493,8 +494,7 @@ type ElTransaction struct {
 
 // ElTransactionInternal is a lightweight index of internal calls from call traces.
 type ElTransactionInternal struct {
-	BlockUid  uint64  `db:"block_uid"`
-	TxHash    []byte  `db:"tx_hash"`
+	TxUid     uint64  `db:"tx_uid"`     // block_uid << 16 | tx_index
 	TxCallIdx uint32  `db:"tx_callidx"` // Depth-first traversal index (0=top-level, skipped)
 	CallType  uint8   `db:"call_type"`  // 0=CALL, 1=STATICCALL, 2=DELEGATECALL, 3=CREATE, 4=CREATE2, 5=SELFDESTRUCT
 	FromID    uint64  `db:"from_id"`
@@ -505,8 +505,7 @@ type ElTransactionInternal struct {
 
 // ElEventIndex is a lightweight searchable index for events (full data in blockdb).
 type ElEventIndex struct {
-	BlockUid   uint64 `db:"block_uid"`
-	TxHash     []byte `db:"tx_hash"`
+	TxUid      uint64 `db:"tx_uid"` // block_uid << 16 | tx_index
 	EventIndex uint32 `db:"event_index"`
 	SourceID   uint64 `db:"source_id"`
 	Topic1     []byte `db:"topic1"`
@@ -555,9 +554,7 @@ type ElBalance struct {
 }
 
 type ElTokenTransfer struct {
-	BlockUid   uint64  `db:"block_uid"`
-	TxHash     []byte  `db:"tx_hash"`
-	TxPos      uint32  `db:"tx_pos"` // Transaction index in block
+	TxUid      uint64  `db:"tx_uid"` // block_uid << 16 | tx_index
 	TxIdx      uint32  `db:"tx_idx"` // Transfer index within transaction
 	TokenID    uint64  `db:"token_id"`
 	TokenType  uint8   `db:"token_type"`

--- a/dbtypes/dbtypes.go
+++ b/dbtypes/dbtypes.go
@@ -488,7 +488,6 @@ type ElTransaction struct {
 	BlobCount   uint32  `db:"blob_count"`
 	BlockNumber uint64  `db:"block_number"`
 	TxType      uint8   `db:"tx_type"`
-	TxIndex     uint32  `db:"tx_index"`
 	EffGasPrice float64 `db:"eff_gas_price"` // Effective gas price actually paid (in Gwei)
 }
 

--- a/handlers/address.go
+++ b/handlers/address.go
@@ -434,21 +434,28 @@ func loadTokenTransfersTab(ctx context.Context, pageData *models.AddressPageData
 		tokenTypes = []uint8{tokenTypeERC721, tokenTypeERC1155}
 	}
 
-	// Get token transfers using combined query (sorted by block_uid DESC, tx_pos DESC, tx_idx DESC)
+	// Get token transfers using combined query (sorted by tx_uid DESC, tx_idx DESC)
 	dbTransfers, totalCount, countCapped, _ := db.GetElTokenTransfersByAccountIDCombined(ctx, account.ID, tokenTypes, offset, limit)
 
 	// Collect IDs for batch lookup
 	accountIDs := make(map[uint64]bool, len(dbTransfers)*2)
 	tokenIDs := make(map[uint64]bool, len(dbTransfers))
-	blockUids := make([]uint64, 0, len(dbTransfers))
 	blockUidSet := make(map[uint64]bool, len(dbTransfers))
+	blockUids := make([]uint64, 0, len(dbTransfers))
+	txUidSet := make(map[uint64]bool, len(dbTransfers))
+	txUids := make([]uint64, 0, len(dbTransfers))
 	for _, t := range dbTransfers {
 		accountIDs[t.FromID] = true
 		accountIDs[t.ToID] = true
 		tokenIDs[t.TokenID] = true
-		if !blockUidSet[t.BlockUid] {
-			blockUidSet[t.BlockUid] = true
-			blockUids = append(blockUids, t.BlockUid)
+		blockUid := t.TxUid >> 16
+		if !blockUidSet[blockUid] {
+			blockUidSet[blockUid] = true
+			blockUids = append(blockUids, blockUid)
+		}
+		if !txUidSet[t.TxUid] {
+			txUidSet[t.TxUid] = true
+			txUids = append(txUids, t.TxUid)
 		}
 	}
 
@@ -495,29 +502,18 @@ func loadTokenTransfersTab(ctx context.Context, pageData *models.AddressPageData
 		}
 	}
 
-	// Collect unique transaction hashes for method signature lookup
-	txHashSet := make(map[string]bool)
-	for _, t := range dbTransfers {
-		txHashKey := string(t.TxHash)
-		txHashSet[txHashKey] = true
-	}
-
-	// Look up transaction method IDs for method signatures
-	txHashList := make([][]byte, 0, len(txHashSet))
-	for txHashKey := range txHashSet {
-		txHashList = append(txHashList, []byte(txHashKey))
-	}
-
-	// Batch fetch transaction data for signature lookup
+	// Batch fetch transaction data by tx_uid for tx_hash and method signature lookup
 	type txInfo struct {
+		TxHash   []byte
 		MethodID []byte
 		ToID     uint64
 	}
-	txInfoMap := make(map[string]*txInfo, len(txHashList))
-	if len(txHashList) > 0 {
-		if txs, err := db.GetElTransactionsByHashes(ctx, txHashList); err == nil {
+	txInfoMap := make(map[uint64]*txInfo, len(txUids))
+	if len(txUids) > 0 {
+		if txs, err := db.GetElTransactionsByTxUids(ctx, txUids); err == nil {
 			for _, tx := range txs {
-				txInfoMap[string(tx.TxHash)] = &txInfo{
+				txInfoMap[tx.TxUid] = &txInfo{
+					TxHash:   tx.TxHash,
 					MethodID: tx.MethodID,
 					ToID:     tx.ToID,
 				}
@@ -543,11 +539,11 @@ func loadTokenTransfersTab(ctx context.Context, pageData *models.AddressPageData
 	// Collect function signatures for batch lookup
 	sysContracts := services.GlobalBeaconService.GetSystemContractAddresses()
 	sigLookupBytes := []types.TxSignatureBytes{}
-	sigLookupMap := make(map[types.TxSignatureBytes][]string) // signature -> tx_hashes
-	methodNameMap := make(map[string]string)                  // tx_hash -> method_name
-	for txHashKey, info := range txInfoMap {
+	sigLookupMap := make(map[types.TxSignatureBytes][]uint64) // signature -> tx_uids
+	methodNameMap := make(map[uint64]string)                  // tx_uid -> method_name
+	for txUid, info := range txInfoMap {
 		if len(info.MethodID) < 4 {
-			methodNameMap[txHashKey] = "transfer"
+			methodNameMap[txUid] = "transfer"
 			continue
 		}
 
@@ -560,17 +556,17 @@ func loadTokenTransfersTab(ctx context.Context, pageData *models.AddressPageData
 
 		// Skip fn signature lookup for deployments, precompiles, and system contracts
 		if skip, altName := utils.ShouldSkipSignatureLookup(toAddr, isCreate, sysContracts); skip {
-			methodNameMap[txHashKey] = altName
+			methodNameMap[txUid] = altName
 			continue
 		}
 
 		var sigBytes types.TxSignatureBytes
 		copy(sigBytes[:], info.MethodID[0:4])
 		if sigLookupMap[sigBytes] == nil {
-			sigLookupMap[sigBytes] = []string{txHashKey}
+			sigLookupMap[sigBytes] = []uint64{txUid}
 			sigLookupBytes = append(sigLookupBytes, sigBytes)
 		} else {
-			sigLookupMap[sigBytes] = append(sigLookupMap[sigBytes], txHashKey)
+			sigLookupMap[sigBytes] = append(sigLookupMap[sigBytes], txUid)
 		}
 	}
 
@@ -582,8 +578,8 @@ func loadTokenTransfersTab(ctx context.Context, pageData *models.AddressPageData
 			if sigLookup.Status == types.TxSigStatusFound {
 				methodName = sigLookup.Name
 			}
-			for _, txHashKey := range sigLookupMap[sigBytes] {
-				methodNameMap[txHashKey] = methodName
+			for _, txUid := range sigLookupMap[sigBytes] {
+				methodNameMap[txUid] = methodName
 			}
 		}
 	}
@@ -591,12 +587,18 @@ func loadTokenTransfersTab(ctx context.Context, pageData *models.AddressPageData
 	// Build transfer list
 	transfers := make([]*models.AddressPageDataTokenTransfer, 0, len(dbTransfers))
 	for _, t := range dbTransfers {
-		slot := t.BlockUid >> 16
+		blockUid := t.TxUid >> 16
+		slot := t.TxUid >> 32
 		blockTime := chainState.SlotToTime(phase0.Slot(slot))
 
+		var txHash []byte
+		if info, ok := txInfoMap[t.TxUid]; ok {
+			txHash = info.TxHash
+		}
+
 		transfer := &models.AddressPageDataTokenTransfer{
-			TxHash:     t.TxHash,
-			BlockUid:   t.BlockUid,
+			TxHash:     txHash,
+			BlockUid:   blockUid,
 			BlockTime:  blockTime,
 			FromID:     t.FromID,
 			ToID:       t.ToID,
@@ -606,11 +608,11 @@ func loadTokenTransfersTab(ctx context.Context, pageData *models.AddressPageData
 			TokenIndex: t.TokenIndex,
 			Amount:     t.Amount,
 			AmountRaw:  t.AmountRaw,
-			MethodName: methodNameMap[string(t.TxHash)],
+			MethodName: methodNameMap[t.TxUid],
 		}
 
 		// Set block root and orphaned status from block lookup
-		if blockInfo, ok := blockMap[t.BlockUid]; ok && blockInfo.Block != nil {
+		if blockInfo, ok := blockMap[blockUid]; ok && blockInfo.Block != nil {
 			transfer.BlockRoot = blockInfo.Block.Root
 			transfer.BlockOrphaned = blockInfo.Block.Status == dbtypes.Orphaned
 			if blockInfo.Block.EthBlockNumber != nil {
@@ -707,16 +709,23 @@ func loadInternalTxsTab(ctx context.Context, pageData *models.AddressPageData, a
 	pageData.InternalTxFirstItem = (pageIdx-1)*uint64(limit) + 1
 	pageData.InternalTxLastItem = min(pageIdx*uint64(limit), totalCount)
 
-	// Collect account IDs and block UIDs for batch lookup
+	// Collect account IDs, block UIDs, and tx UIDs for batch lookup
 	accountIDs := make(map[uint64]bool, len(dbEntries)*2)
-	blockUids := make([]uint64, 0, len(dbEntries))
 	blockUidSet := make(map[uint64]bool, len(dbEntries))
+	blockUids := make([]uint64, 0, len(dbEntries))
+	txUidSet := make(map[uint64]bool, len(dbEntries))
+	txUids := make([]uint64, 0, len(dbEntries))
 	for _, e := range dbEntries {
 		accountIDs[e.FromID] = true
 		accountIDs[e.ToID] = true
-		if !blockUidSet[e.BlockUid] {
-			blockUidSet[e.BlockUid] = true
-			blockUids = append(blockUids, e.BlockUid)
+		blockUid := e.TxUid >> 16
+		if !blockUidSet[blockUid] {
+			blockUidSet[blockUid] = true
+			blockUids = append(blockUids, blockUid)
+		}
+		if !txUidSet[e.TxUid] {
+			txUidSet[e.TxUid] = true
+			txUids = append(txUids, e.TxUid)
 		}
 	}
 
@@ -749,6 +758,16 @@ func loadInternalTxsTab(ctx context.Context, pageData *models.AddressPageData, a
 		}
 	}
 
+	// Batch lookup tx_hash from el_transactions by tx_uid
+	txHashMap := make(map[uint64][]byte, len(txUids))
+	if len(txUids) > 0 {
+		if txs, err := db.GetElTransactionsByTxUids(ctx, txUids); err == nil {
+			for _, tx := range txs {
+				txHashMap[tx.TxUid] = tx.TxHash
+			}
+		}
+	}
+
 	// Call type names
 	callTypeNames := map[uint8]string{
 		0: "CALL",
@@ -762,12 +781,13 @@ func loadInternalTxsTab(ctx context.Context, pageData *models.AddressPageData, a
 	// Build internal transaction list
 	pageData.InternalTxs = make([]*models.AddressPageDataInternalTransaction, 0, len(dbEntries))
 	for _, e := range dbEntries {
-		slot := e.BlockUid >> 16
+		blockUid := e.TxUid >> 16
+		slot := e.TxUid >> 32
 		blockTime := chainState.SlotToTime(phase0.Slot(slot))
 
 		itx := &models.AddressPageDataInternalTransaction{
-			TxHash:     e.TxHash,
-			BlockUid:   e.BlockUid,
+			TxHash:     txHashMap[e.TxUid],
+			BlockUid:   blockUid,
 			BlockTime:  blockTime,
 			CallIndex:  e.TxCallIdx,
 			CallType:   e.CallType,
@@ -785,7 +805,7 @@ func loadInternalTxsTab(ctx context.Context, pageData *models.AddressPageData, a
 		}
 
 		// Set block info
-		if blockInfo, ok := blockMap[e.BlockUid]; ok && blockInfo.Block != nil {
+		if blockInfo, ok := blockMap[blockUid]; ok && blockInfo.Block != nil {
 			itx.BlockRoot = blockInfo.Block.Root
 			itx.BlockOrphaned = blockInfo.Block.Status == dbtypes.Orphaned
 			if blockInfo.Block.EthBlockNumber != nil {

--- a/handlers/transaction.go
+++ b/handlers/transaction.go
@@ -249,7 +249,7 @@ func buildTransactionPageDataFromDB(ctx context.Context, pageData *models.Transa
 			BlockTime:   blockTime,
 			IsOrphaned:  isOrphaned,
 			IsCanonical: isCanonical,
-			TxIndex:     tx.TxIndex,
+			TxIndex:     uint32(tx.TxUid & 0xFFFF),
 		}
 		pageData.InclusionBlocks = append(pageData.InclusionBlocks, inclusionBlock)
 
@@ -378,7 +378,7 @@ func buildTransactionPageDataFromDB(ctx context.Context, pageData *models.Transa
 		pageData.TxTypeName = fmt.Sprintf("Type %d", tx.TxType)
 	}
 	pageData.Nonce = tx.Nonce
-	pageData.TxIndex = tx.TxIndex
+	pageData.TxIndex = uint32(tx.TxUid & 0xFFFF)
 
 	// Load full transaction data from selected beacon block (must come before
 	// method resolution so InputData is available for calldata decoding).
@@ -1307,12 +1307,13 @@ func loadFullTransactionData(ctx context.Context, pageData *models.TransactionPa
 		return
 	}
 
-	if int(tx.TxIndex) >= len(execTxs) {
+	txIndex := tx.TxUid & 0xFFFF
+	if int(txIndex) >= len(execTxs) {
 		logrus.Debug("transaction index out of range")
 		return
 	}
 
-	rlpData := execTxs[tx.TxIndex]
+	rlpData := execTxs[txIndex]
 
 	// Store RLP as hex string for copy button
 	pageData.TxRLP = "0x" + hex.EncodeToString(rlpData)

--- a/handlers/transaction.go
+++ b/handlers/transaction.go
@@ -404,13 +404,13 @@ func buildTransactionPageDataFromDB(ctx context.Context, pageData *models.Transa
 	// Load tab badge counts using lightweight COUNT queries instead of
 	// loading all rows. This avoids multi-second sequential scans for
 	// transactions with many events or internal calls.
-	eventCount, _ := db.GetElEventIndexCountByTxHash(ctx, pageData.TxHash)
+	eventCount, _ := db.GetElEventIndexCountByTxUid(ctx, tx.TxUid)
 	pageData.EventCount = eventCount
 
-	transferCount, _ := db.GetElTokenTransferCountByBlockUidAndTxHash(ctx, tx.BlockUid, pageData.TxHash)
+	transferCount, _ := db.GetElTokenTransferCountByTxUid(ctx, tx.TxUid)
 	pageData.TokenTransferCount = transferCount
 
-	internalTxCount, _ := db.GetElTransactionsInternalCountByTxHash(ctx, pageData.TxHash)
+	internalTxCount, _ := db.GetElTransactionsInternalCountByTxUid(ctx, tx.TxUid)
 	pageData.InternalTxCount = internalTxCount
 
 	// Load tab-specific detailed data. Full row data is only loaded for
@@ -418,12 +418,12 @@ func buildTransactionPageDataFromDB(ctx context.Context, pageData *models.Transa
 	// are loaded from blockdb when available, falling back to DB.
 	switch tabView {
 	case "events":
-		loadTransactionEventsFromBlockdb(ctx, pageData, tx.BlockUid)
+		loadTransactionEventsFromBlockdb(ctx, pageData, tx.BlockUid, tx.TxUid)
 	case "transfers":
-		transfers, _ := db.GetElTokenTransfersByBlockUidAndTxHash(ctx, tx.BlockUid, pageData.TxHash)
+		transfers, _ := db.GetElTokenTransfersByTxUid(ctx, tx.TxUid)
 		loadTransactionTransfersFromData(ctx, pageData, transfers)
 	case "internaltxs":
-		loadTransactionInternalTxsFromBlockdb(ctx, pageData, tx.BlockUid)
+		loadTransactionInternalTxsFromBlockdb(ctx, pageData, tx.BlockUid, tx.TxUid)
 		computeInternalTxIndent(pageData)
 	case "statechanges":
 		loadTransactionStateChangesFromBlockdb(ctx, pageData, tx.BlockUid)
@@ -724,7 +724,7 @@ func loadTransactionEventsFromIndex(ctx context.Context, pageData *models.Transa
 // loadTransactionEventsFromBlockdb populates the events tab with full event
 // data from blockdb (all topics + data blob). Falls back to loading from
 // the DB event index if blockdb data is unavailable (pruned or not stored).
-func loadTransactionEventsFromBlockdb(ctx context.Context, pageData *models.TransactionPageData, blockUid uint64) {
+func loadTransactionEventsFromBlockdb(ctx context.Context, pageData *models.TransactionPageData, blockUid uint64, txUid uint64) {
 	if pageData.EventCount == 0 {
 		return
 	}
@@ -773,7 +773,7 @@ func loadTransactionEventsFromBlockdb(ctx context.Context, pageData *models.Tran
 	}
 
 	// Fallback: load from DB event index (only when blockdb is unavailable)
-	eventIndices, _ := db.GetElEventIndicesByTxHash(ctx, pageData.TxHash)
+	eventIndices, _ := db.GetElEventIndicesByTxUid(ctx, txUid)
 	loadTransactionEventsFromIndex(ctx, pageData, eventIndices)
 }
 
@@ -956,7 +956,7 @@ var callTypeNames = map[uint8]string{
 // loadTransactionInternalTxsFromBlockdb populates the internal transactions tab
 // with rich call trace data from blockdb (depth, input, output, gas, status).
 // Falls back to loading from the DB index if blockdb data is unavailable.
-func loadTransactionInternalTxsFromBlockdb(ctx context.Context, pageData *models.TransactionPageData, blockUid uint64) {
+func loadTransactionInternalTxsFromBlockdb(ctx context.Context, pageData *models.TransactionPageData, blockUid uint64, txUid uint64) {
 	if pageData.InternalTxCount == 0 {
 		return
 	}
@@ -1004,7 +1004,7 @@ func loadTransactionInternalTxsFromBlockdb(ctx context.Context, pageData *models
 	}
 
 	// Fallback: load from DB index (only when blockdb is unavailable)
-	entries, _ := db.GetElTransactionsInternalByTxHash(ctx, pageData.TxHash)
+	entries, _ := db.GetElTransactionsInternalByTxUid(ctx, txUid)
 	loadTransactionInternalTxsFromDB(ctx, pageData, entries)
 }
 

--- a/indexer/execution/txindexer/process_transactions.go
+++ b/indexer/execution/txindexer/process_transactions.go
@@ -261,9 +261,8 @@ func (ctx *txProcessingContext) processTransaction(
 		methodID = tx.Data()[:4]
 	}
 
-	txIndex := uint32(receipt.TransactionIndex)
 	result.transaction = &dbtypes.ElTransaction{
-		TxUid:       ctx.block.BlockUID<<16 | uint64(txIndex),
+		TxUid:       ctx.block.BlockUID<<16 | uint64(receipt.TransactionIndex),
 		BlockUid:    ctx.block.BlockUID,
 		TxHash:      txHash[:],
 		FromID:      fromAccount.id,
@@ -280,7 +279,6 @@ func (ctx *txProcessingContext) processTransaction(
 		BlobCount:   blobCount,
 		BlockNumber: receipt.BlockNumber.Uint64(),
 		TxType:      tx.Type(),
-		TxIndex:     txIndex,
 		EffGasPrice: effGasPrice,
 	}
 

--- a/indexer/execution/txindexer/process_transactions.go
+++ b/indexer/execution/txindexer/process_transactions.go
@@ -261,7 +261,9 @@ func (ctx *txProcessingContext) processTransaction(
 		methodID = tx.Data()[:4]
 	}
 
+	txIndex := uint32(receipt.TransactionIndex)
 	result.transaction = &dbtypes.ElTransaction{
+		TxUid:       ctx.block.BlockUID<<16 | uint64(txIndex),
 		BlockUid:    ctx.block.BlockUID,
 		TxHash:      txHash[:],
 		FromID:      fromAccount.id,
@@ -278,7 +280,7 @@ func (ctx *txProcessingContext) processTransaction(
 		BlobCount:   blobCount,
 		BlockNumber: receipt.BlockNumber.Uint64(),
 		TxType:      tx.Type(),
-		TxIndex:     uint32(receipt.TransactionIndex),
+		TxIndex:     txIndex,
 		EffGasPrice: effGasPrice,
 	}
 
@@ -827,9 +829,7 @@ func (ctx *txProcessingContext) createTokenTransfer(
 	// If metadata IS loaded, use the actual decimals value (even if 0)
 
 	transfer := &dbtypes.ElTokenTransfer{
-		BlockUid:   ctx.block.BlockUID,
-		TxHash:     make([]byte, 32), // Will be set in commit
-		TxPos:      txPos,
+		TxUid:      0, // Will be set in commit from result.transaction.TxUid
 		TxIdx:      eventIndex,
 		TokenID:    0, // Will be set in commit from pendingToken.id
 		TokenType:  tokenType,
@@ -1111,8 +1111,7 @@ func (ctx *txProcessingContext) commitTransaction(commitCtx context.Context, dbT
 		eventIndices := make([]*dbtypes.ElEventIndex, 0, len(result.events))
 		for _, pe := range result.events {
 			eventIndices = append(eventIndices, &dbtypes.ElEventIndex{
-				BlockUid:   ctx.block.BlockUID,
-				TxHash:     pe.txHash,
+				TxUid:      result.transaction.TxUid,
 				EventIndex: pe.eventIndex,
 				SourceID:   pe.sourceAccount.id,
 				Topic1:     pe.topic1,
@@ -1128,9 +1127,9 @@ func (ctx *txProcessingContext) commitTransaction(commitCtx context.Context, dbT
 	if len(result.tokenTransfers) > 0 {
 		transfers := make([]*dbtypes.ElTokenTransfer, 0, len(result.tokenTransfers))
 		for _, pt := range result.tokenTransfers {
-			// Set tx hash from result
+			// Set tx_uid from result
 			if result.transaction != nil {
-				pt.transfer.TxHash = result.transaction.TxHash
+				pt.transfer.TxUid = result.transaction.TxUid
 			}
 
 			// Resolve token ID from pendingToken (always set now)
@@ -1155,8 +1154,7 @@ func (ctx *txProcessingContext) commitTransaction(commitCtx context.Context, dbT
 		internalEntries := make([]*dbtypes.ElTransactionInternal, 0, len(result.internalCalls))
 		for _, ic := range result.internalCalls {
 			internalEntries = append(internalEntries, &dbtypes.ElTransactionInternal{
-				BlockUid:  ctx.block.BlockUID,
-				TxHash:    result.transaction.TxHash,
+				TxUid:     result.transaction.TxUid,
 				TxCallIdx: ic.txCallIdx,
 				CallType:  ic.callType,
 				FromID:    ic.fromAccount.id,


### PR DESCRIPTION
## Summary

Introduces `tx_uid` — a compact 8-byte transaction identifier that replaces the redundant `(block_uid, tx_hash)` composite key in execution indexing tables, significantly reducing storage and index overhead.

### tx_uid encoding

```
tx_uid = block_uid << 16 | tx_index
       = (slot << 16 | block_unique_index) << 16 | tx_position
```

- **block_uid** recoverable as `tx_uid >> 16`
- **tx_index** recoverable as `tx_uid & 0xFFFF`
- **slot** recoverable as `tx_uid >> 32`
- Max slot ~2.1B (signed BIGINT) = **817+ years** on mainnet at 12s slots

### Schema changes

**el_transactions** — keeps `block_uid`, adds `tx_uid`, drops `tx_index`:
- `tx_uid` added as a UNIQUE indexed column (`block_uid << 16 | tx_index`)
- `tx_index` dropped (derivable from `tx_uid & 0xFFFF`)
- Primary key remains `(block_uid, tx_hash)` for efficient block-based and hash-based lookups

**el_event_index** — `(block_uid, tx_hash, event_index)` → `(tx_uid, event_index)`:
- Drops `block_uid` (8 bytes) and `tx_hash` (32 bytes)
- Replaces with `tx_uid` (8 bytes)
- **Saves 32 bytes per row**

**el_token_transfers** — `(block_uid, tx_hash, tx_idx)` → `(tx_uid, tx_idx)`:
- Drops `block_uid` (8 bytes), `tx_hash` (32 bytes), and `tx_pos` (4 bytes)
- Replaces with `tx_uid` (8 bytes)
- **Saves 36 bytes per row**

**el_transactions_internal** — `(block_uid, tx_hash, tx_callidx)` → `(tx_uid, tx_callidx)`:
- Drops `block_uid` (8 bytes) and `tx_hash` (32 bytes)
- Replaces with `tx_uid` (8 bytes)
- **Saves 32 bytes per row**

### Storage reduction estimate

Assumptions: mainnet-scale, 200 txs/block, ~2.5 events/tx, ~4 token transfers/tx, ~6.5 internal calls/tx.

Estimates include heap data + all associated indexes (PK + secondary). Dependent tables see large reductions because the 32-byte `tx_hash` and 8-byte `block_uid` are replaced by a single 8-byte `tx_uid` in both row data and every index entry.

| Table | Row data | PK key size | Removed indexes | Reduction |
|---|---|---|---|---:|
| el_event_index | -32 bytes/row | 44 → 12 bytes | tx_hash_idx | **~47%** |
| el_token_transfers | -36 bytes/row | 44 → 12 bytes | tx_hash_idx, block_uid_idx | **~42%** |
| el_transactions_internal | -32 bytes/row | 44 → 12 bytes | tx_hash_idx | **~47%** |
| el_transactions | +4 bytes/row | unchanged | swapped block_uid_idx → tx_uid_idx | **~0%** |

The three dependent tables hold ~93% of all execution index rows (events, transfers, and internal calls vastly outnumber transactions). The weighted overall reduction across all four tables is approximately **~45%**.

### Query changes

- Dependent table queries now use `tx_uid` instead of `(block_uid, tx_hash)` for all lookups
- `ORDER BY block_uid DESC, tx_index DESC` → `ORDER BY tx_uid DESC` (equivalent ordering)
- Address page handlers batch-fetch `tx_hash` from `el_transactions` via `GetElTransactionsByTxUids()` when needed for display
- Cleanup uses `WHERE tx_uid < threshold` for dependent tables (threshold = `blockUidThreshold << 16`)

### Migration

The migration (`20260417000000_tx-uid`) performs the following in a single transaction:
1. Adds `tx_uid` column to `el_transactions` and populates it
2. Recreates each dependent table with `tx_uid` via JOIN, migrating existing data
3. Drops `tx_index` from `el_transactions`
4. Rebuilds all affected indexes

Both PostgreSQL and SQLite migrations are included.

## Test plan

- [x] Run migration on a database with existing execution index data
- [x] Verify transaction detail page shows correct data (events, transfers, internal txs tabs)
- [x] Verify address page shows correct token transfers and internal transactions
- [x] Verify slot page still enriches transactions with EL data
- [x] Verify new blocks are indexed correctly after migration
- [x] Verify retention cleanup still works (deletes old data by block threshold)
- [x] Verify reorg handling (orphaned blocks have distinct tx_uids)
