### PR TITLE
fix Redis bool cache key prefix

### DIFF
--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -72,7 +72,7 @@ func (cache *RedisCache) SetBool(ctx context.Context, key string, value bool, ex
 
 func (cache *RedisCache) GetBool(ctx context.Context, key string) (bool, error) {
 
-	value, err := cache.redisRemoteCache.Get(ctx, key).Result()
+	value, err := cache.redisRemoteCache.Get(ctx, fmt.Sprintf("%s%s", cache.keyPrefix, key)).Result()
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Summary

Fixes `RedisCache.GetBool` to use the configured Redis key prefix when reading values.

`SetBool` writes bool values using the prefixed key, but `GetBool` previously looked up the raw unprefixed key. This meant bool values stored through `SetBool` would not be found when a Redis prefix was configured.

## Changes

- Updated `GetBool` to read from the same prefixed key format used by `SetBool`.