### PR TITLE
Bump go-eth2-client to ethpandaops master for v1.7.0-alpha.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethpandaops/eth-das-guardian v0.1.0
 	github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c
 	github.com/ethpandaops/ethwallclock v0.4.0
-	github.com/ethpandaops/go-eth2-client v0.0.1
+	github.com/ethpandaops/go-eth2-client v0.0.2-0.20260420095341-76d6596ff4bc
 	github.com/glebarez/go-sqlite v1.22.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c h1:uBRIitwcuCJ
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c/go.mod h1:QsmYTdesob+vQ6pW4KtRVvxLZUNop3cdtd/DgD30hJU=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=
 github.com/ethpandaops/ethwallclock v0.4.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
-github.com/ethpandaops/go-eth2-client v0.0.1 h1:Xifvb7RF24tguA6HxEaE2vIN1BsY44SOSH/B+CBSFPk=
-github.com/ethpandaops/go-eth2-client v0.0.1/go.mod h1:9BBd/XIw1egZTkxtFGMvgXnsxX6ypKHKNKD7itqjmNQ=
+github.com/ethpandaops/go-eth2-client v0.0.2-0.20260420095341-76d6596ff4bc h1:Kxvw0SR67oZ3hz70tXIYGrtXcid+r3xoNYlCX13ZOdo=
+github.com/ethpandaops/go-eth2-client v0.0.2-0.20260420095341-76d6596ff4bc/go.mod h1:9BBd/XIw1egZTkxtFGMvgXnsxX6ypKHKNKD7itqjmNQ=
 github.com/ferranbt/fastssz v1.0.0 h1:9EXXYsracSqQRBQiHeaVsG/KQeYblPf40hsQPb9Dzk8=
 github.com/ferranbt/fastssz v1.0.0/go.mod h1:Ea3+oeoRGGLGm5shYAeDgu6PGUlcvQhE2fILyD9+tGg=
 github.com/filecoin-project/go-clock v0.1.0 h1:SFbYIM75M8NnFm1yMHhN9Ahy3W5bEZV9gd6MPfXbKVU=

--- a/indexer/beacon/epochstate.go
+++ b/indexer/beacon/epochstate.go
@@ -486,8 +486,15 @@ func (s *epochState) tryReplayFromParentState(
 						client.logger.Warnf("replay: ApplyExecutionPayload failed at slot %v: %v", blk.Slot, err)
 						return nil
 					}
-					// Post-payload state HTR is recorded in the envelope itself.
-					prevStateRoot = payload.Message.StateRoot
+					// Post-payload state HTR: compute from the applied state.
+					// v1.7.0-alpha.5 removed state_root from ExecutionPayloadEnvelope,
+					// so we derive it locally instead of reading it off the envelope.
+					postPayloadRoot, htrErr := parentState.Gloas.HashTreeRoot()
+					if htrErr != nil {
+						client.logger.Warnf("replay: post-payload HTR failed at slot %v: %v", blk.Slot, htrErr)
+						return nil
+					}
+					prevStateRoot = postPayloadRoot
 				}
 				// else: payload was orphaned (next block built on parent payload).
 				// Leave state unchanged; gotStateRoot is the correct hint.


### PR DESCRIPTION
## Summary

Upgrade \`github.com/ethpandaops/go-eth2-client\` from \`v0.0.1\` to master (\`v0.0.2-0.20260420095341-76d6596ff4bc\` / commit \`76d6596\`), which carries the consensus-specs v1.7.0-alpha.5 spec updates:

- \`execution_requests_root\` added to \`ExecutionPayloadBid\`.
- \`parent_execution_requests\` added to \`BeaconBlockBodyGloas\`.
- \`state_root\` removed from \`ExecutionPayloadEnvelope\`.
- Various field-order and naming fixes per consensus-specs #5108, #5113, #5117, etc.

### Why

Running dora against a gloas-at-alpha.5 network (geth \`glamsterdam-devnet-0\` + Prysm \`v1.7.0-alpha.5\`) currently fails to decode recent beacon state/block SSZ because the struct layouts on \`v0.0.1\` predate alpha.5.

### Changes

- \`go.mod\` / \`go.sum\` — bump \`ethpandaops/go-eth2-client\` to master.
- \`indexer/beacon/epochstate.go\` — derive the post-payload state HTR locally via \`parentState.Gloas.HashTreeRoot()\` after \`ApplyExecutionPayload\`, since the envelope no longer carries a \`state_root\` field in alpha.5. Previously read via \`payload.Message.StateRoot\`, which no longer exists on the struct.

## Test plan

- [x] \`go build ./...\`
- [ ] Run against a live alpha.5 devnet and verify epoch replay continues to track post-payload state roots through gloas slots.