### PR TITLE
fix: only apply beaconapi.clientIndex filter when explicitly set

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -97,7 +97,7 @@ type Config struct {
 		Endpoint     string           `yaml:"endpoint" envconfig:"BEACONAPI_ENDPOINT"`
 		Endpoints    []EndpointConfig `yaml:"endpoints"`
 		EndpointsURL string           `yaml:"endpointsUrl" envconfig:"BEACONAPI_ENDPOINTS_URL"`
-		ClientIndex  int              `yaml:"clientIndex" envconfig:"BEACONAPI_CLIENT_INDEX"`
+		ClientIndex  *int             `yaml:"clientIndex" envconfig:"BEACONAPI_CLIENT_INDEX"`
 
 		LocalCacheSize       int    `yaml:"localCacheSize" envconfig:"BEACONAPI_LOCAL_CACHE_SIZE"`
 		SkipFinalAssignments bool   `yaml:"skipFinalAssignments" envconfig:"BEACONAPI_SKIP_FINAL_ASSIGNMENTS"`

--- a/utils/config.go
+++ b/utils/config.go
@@ -46,9 +46,9 @@ func ReadConfig(cfg *types.Config, path string) error {
 		}
 	}
 
-	// ClientIndex selects a specific endpoint by index (0-based)
-	if cfg.BeaconApi.ClientIndex >= 0 && cfg.BeaconApi.ClientIndex < len(cfg.BeaconApi.Endpoints) {
-		selectedEndpoint := cfg.BeaconApi.Endpoints[cfg.BeaconApi.ClientIndex]
+	// ClientIndex selects a specific endpoint by index (0-based), when explicitly set
+	if cfg.BeaconApi.ClientIndex != nil && *cfg.BeaconApi.ClientIndex >= 0 && *cfg.BeaconApi.ClientIndex < len(cfg.BeaconApi.Endpoints) {
+		selectedEndpoint := cfg.BeaconApi.Endpoints[*cfg.BeaconApi.ClientIndex]
 		cfg.BeaconApi.Endpoints = []types.EndpointConfig{selectedEndpoint}
 	}
 


### PR DESCRIPTION
## Summary
- `beaconapi.ClientIndex` was typed `int`, so its Go zero value (`0`) always satisfied the `>= 0` check in `utils.ReadConfig`, collapsing `beaconapi.endpoints` down to `endpoints[0]` for users who never set `clientIndex`. Multi-endpoint setups only ever exposed the first beacon client on `/clients/consensus` and in the indexer.
- Change `ClientIndex` to `*int` so `nil` means "unset"; the single-endpoint selection now only runs when the field is explicitly configured (YAML or `BEACONAPI_CLIENT_INDEX`).
- Regression introduced in 11f18e66 (Nov 2025).

## Test plan
- [x] Verified locally against a Kurtosis enclave with two beacon endpoints and no `clientIndex`: prior to the fix only `1-geth-prysm` appeared on `/clients/consensus`; after the fix both `1-geth-prysm` and `2-geth-prysm` are listed and indexed.
- [x] `go build ./...` passes.
- [ ] Still honors explicit `clientIndex: N` (selects a single endpoint) and `BEACONAPI_CLIENT_INDEX` env var.