### PR TITLE
log: raise BAL decode failures to error level

### DIFF
--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -946,7 +946,7 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 		if len(blockData.BlockAccessList) > 0 {
 			accesses, err := utils.DecodeBlockAccessList(blockData.BlockAccessList)
 			if err != nil {
-				logrus.Warnf("error decoding block access list for slot %v: %v", blockData.Header.Message.Slot, err)
+				logrus.Errorf("error decoding block access list for slot %v: %v", blockData.Header.Message.Slot, err)
 			} else {
 				pageData.ExecutionData.BlockAccessList = convertBALToModel(accesses)
 			}

--- a/services/chainservice_blocks.go
+++ b/services/chainservice_blocks.go
@@ -396,7 +396,7 @@ func (bs *ChainService) populateBlockAccessList(ctx context.Context, result *Com
 
 	bal, err := beacon.UnmarshalBlockAccessList(blockData.BalVersion, blockData.BalData)
 	if err != nil {
-		logrus.WithError(err).Warnf("failed to decode BAL from blockdb for block 0x%x", result.Root[:])
+		logrus.WithError(err).Errorf("failed to decode BAL from blockdb for block 0x%x", result.Root[:])
 		return
 	}
 	result.BlockAccessList = bal


### PR DESCRIPTION
## Summary
- BAL decode failures in `handlers/slot.go` and `services/chainservice_blocks.go` were logged at `warn` level, so when the slot view silently dropped the Block Access List section (e.g. after a geth upgrade across EIP-7928 spec churn) there was no obvious signal in the logs.
- Bump both call sites to `error` so format regressions surface immediately in production logs. No behavioural change beyond log level.

## Test plan
- [ ] `go build ./...` (passes locally)
- [ ] Point dora at a devnet where the EL is emitting a BAL that fails to RLP-decode and confirm the error now shows at `level=error` in the logs.