### PR TITLE
fix: clamp sync committee assigned count to available bits

### DIFF
--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -381,13 +381,20 @@ func (dbw *dbWriter) buildDbBlock(block *Block, epochStats *EpochStats, override
 			assignedCount = len(syncAggregate.SyncCommitteeBits) * 8
 		}
 
-		votedCount := 0
-		for i := 0; i < assignedCount; i++ {
-			if utils.BitAtVector(syncAggregate.SyncCommitteeBits, i) {
-				votedCount++
-			}
+		// clamp to bits actually present in the block to avoid out-of-range access on mismatch
+		if maxBits := len(syncAggregate.SyncCommitteeBits) * 8; assignedCount > maxBits {
+			assignedCount = maxBits
 		}
-		dbBlock.SyncParticipation = float32(votedCount) / float32(assignedCount)
+
+		if assignedCount > 0 {
+			votedCount := 0
+			for i := 0; i < assignedCount; i++ {
+				if utils.BitAtVector(syncAggregate.SyncCommitteeBits, i) {
+					votedCount++
+				}
+			}
+			dbBlock.SyncParticipation = float32(votedCount) / float32(assignedCount)
+		}
 	}
 
 	if executionBlockNumber > 0 {
@@ -586,8 +593,12 @@ func (dbw *dbWriter) buildDbEpoch(epoch phase0.Epoch, blocks []*Block, epochStat
 			dbEpoch.BLSChangeCount += uint64(len(blsToExecChanges))
 
 			if syncAggregate != nil && epochStatsValues != nil {
-				votedCount := 0
 				assignedCount := len(epochStatsValues.SyncCommitteeDuties)
+				if maxBits := len(syncAggregate.SyncCommitteeBits) * 8; assignedCount > maxBits {
+					assignedCount = maxBits
+				}
+
+				votedCount := 0
 				for i := 0; i < assignedCount; i++ {
 					if utils.BitAtVector(syncAggregate.SyncCommitteeBits, i) {
 						votedCount++


### PR DESCRIPTION
## Summary
- Fixes a runtime panic (`index out of range [4] with length 4`) in `indexer/beacon/writedb.go` triggered when `epochStatsValues.SyncCommitteeDuties` exceeded the bits present in `syncAggregate.SyncCommitteeBits`.
- Both loops (`buildDbBlock` participation + per-epoch aggregation) now clamp `assignedCount` to `len(SyncCommitteeBits) * 8` before iterating, and the participation ratio guards against a zero denominator.

## Stack trace that motivated this
```
panic: runtime error: index out of range [4] with length 4
github.com/ethpandaops/dora/utils.BitAtVector(...)
  utils/utils.go:54
github.com/ethpandaops/dora/indexer/beacon.(*dbWriter).buildDbBlock
  indexer/beacon/writedb.go:386
```

## Test plan
- [x] `go build ./...`
- [x] `go vet ./indexer/beacon/...`
- [ ] Confirm slots page no longer panics on the affected network