### PR TITLE
 correct EIP-8025 proof type mappings in slot proofs template

### DIFF
--- a/templates/slot/proofs.html
+++ b/templates/slot/proofs.html
@@ -11,9 +11,13 @@
             <div class="col-md-10">
               {{ $proof.ProofId }}
               <span class="text-muted ms-2">
-                {{ if eq $proof.ProofId 0 }}(SP1+Reth)
-                {{ else if eq $proof.ProofId 1 }}(Risc0+Geth)
-                {{ else if eq $proof.ProofId 2 }}(SP1+Geth)
+                {{ if eq $proof.ProofId 0 }}(Risc0+Ethrex)
+                {{ else if eq $proof.ProofId 1 }}(SP1+Ethrex)
+                {{ else if eq $proof.ProofId 2 }}(Zisk+Ethrex)
+                {{ else if eq $proof.ProofId 3 }}(OpenVM+Reth)
+                {{ else if eq $proof.ProofId 4 }}(Risc0+Reth)
+                {{ else if eq $proof.ProofId 5 }}(SP1+Reth)
+                {{ else if eq $proof.ProofId 6 }}(Zisk+Reth)
                 {{ else }}(zkVM+EL #{{ $proof.ProofId }})
                 {{ end }}
               </span>


### PR DESCRIPTION
 ## Summary
  - Fix incorrect proof type ID to name mappings in the slot proofs template
  - Align with canonical EIP-8025 proof types defined in [eth-act Lighthouse fork](https://github.com/eth-act/lighthouse/blob/optional-proofs/beacon_node/execution_layer/src/eip8025/types.rs#L30-L38)