### PR TITLE
fix: scope slot page bids to the current slot

### DIFF
--- a/db/block_bids.go
+++ b/db/block_bids.go
@@ -64,16 +64,17 @@ func InsertBids(bids []*dbtypes.BlockBid, tx *sqlx.Tx) error {
 	return nil
 }
 
-func GetBidsForBlockRoot(ctx context.Context, blockRoot []byte) []*dbtypes.BlockBid {
+func GetBidsForBlockRoot(ctx context.Context, blockRoot []byte, slot uint64) []*dbtypes.BlockBid {
 	var sql strings.Builder
 	args := []any{
 		blockRoot,
+		slot,
 	}
 	fmt.Fprint(&sql, `
 	SELECT
 		parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment
 	FROM block_bids
-	WHERE parent_root = $1
+	WHERE parent_root = $1 AND slot = $2
 	ORDER BY value DESC
 	`)
 

--- a/handlers/builder.go
+++ b/handlers/builder.go
@@ -379,10 +379,10 @@ func buildBuilderRecentBlocks(ctx context.Context, builderIndex uint64, chainSta
 			GasLimit:     slot.EthGasLimit,
 		}
 
-		// Look up bid by parent root, then match by block hash and builder index
+		// Look up bid by parent root and slot, then match by block hash and builder index
 		var parentRoot phase0.Root
 		copy(parentRoot[:], slot.ParentRoot)
-		bids := indexer.GetBlockBids(parentRoot)
+		bids := indexer.GetBlockBids(parentRoot, phase0.Slot(slot.Slot))
 		for _, bid := range bids {
 			if bid.BuilderIndex == builderIndexInt64 && fmt.Sprintf("%x", bid.BlockHash) == fmt.Sprintf("%x", slot.EthBlockHash) {
 				block.Value = bid.Value

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -1381,7 +1381,7 @@ func getSlotPageExecutionProofs(pageData *models.SlotPageBlockData, blockRoot ph
 
 func getSlotPageBids(pageData *models.SlotPageBlockData, blockSlot phase0.Slot) {
 	beaconIndexer := services.GlobalBeaconService.GetBeaconIndexer()
-	bids := beaconIndexer.GetBlockBids(phase0.Root(pageData.ParentRoot))
+	bids := beaconIndexer.GetBlockBids(phase0.Root(pageData.ParentRoot), blockSlot)
 
 	pageData.Bids = make([]*models.SlotPageBid, 0, len(bids))
 
@@ -1392,12 +1392,6 @@ func getSlotPageBids(pageData *models.SlotPageBlockData, blockSlot phase0.Slot) 
 	}
 
 	for _, bid := range bids {
-		// Filter out bids targeting other slots that share this slot's parent root
-		// (bids for orphaned slots between this block and its parent).
-		if bid.Slot != uint64(blockSlot) {
-			continue
-		}
-
 		bidData := &models.SlotPageBid{
 			ParentRoot:   bid.ParentRoot,
 			ParentHash:   bid.ParentHash,

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -1086,7 +1086,7 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 
 	// Load execution payload bids for ePBS (gloas+) blocks
 	if blockData.Block.Version >= spec.DataVersionGloas {
-		getSlotPageBids(pageData)
+		getSlotPageBids(pageData, blockData.Header.Message.Slot)
 		getSlotPagePtcVotes(pageData, blockData, blockData.Header.Message.Slot)
 	}
 
@@ -1379,7 +1379,7 @@ func getSlotPageExecutionProofs(pageData *models.SlotPageBlockData, blockRoot ph
 	pageData.ExecutionProofsCount = uint64(len(pageData.ExecutionProofs))
 }
 
-func getSlotPageBids(pageData *models.SlotPageBlockData) {
+func getSlotPageBids(pageData *models.SlotPageBlockData, blockSlot phase0.Slot) {
 	beaconIndexer := services.GlobalBeaconService.GetBeaconIndexer()
 	bids := beaconIndexer.GetBlockBids(phase0.Root(pageData.ParentRoot))
 
@@ -1392,6 +1392,12 @@ func getSlotPageBids(pageData *models.SlotPageBlockData) {
 	}
 
 	for _, bid := range bids {
+		// Filter out bids targeting other slots that share this slot's parent root
+		// (bids for orphaned slots between this block and its parent).
+		if bid.Slot != uint64(blockSlot) {
+			continue
+		}
+
 		bidData := &models.SlotPageBid{
 			ParentRoot:   bid.ParentRoot,
 			ParentHash:   bid.ParentHash,

--- a/indexer/beacon/bidcache.go
+++ b/indexer/beacon/bidcache.go
@@ -117,14 +117,16 @@ func (cache *blockBidCache) AddBid(bid *dbtypes.BlockBid) bool {
 	return true
 }
 
-// GetBidsForBlockRoot returns all bids for a given parent block root.
-func (cache *blockBidCache) GetBidsForBlockRoot(blockRoot phase0.Root) []*dbtypes.BlockBid {
+// GetBidsForBlockRoot returns all bids for a given parent block root and slot.
+// Filtering by slot is required because orphaned/skipped predecessor slots share
+// the same parent root as the canonical block that ends up replacing them.
+func (cache *blockBidCache) GetBidsForBlockRoot(blockRoot phase0.Root, slot phase0.Slot) []*dbtypes.BlockBid {
 	cache.cacheMutex.RLock()
 	defer cache.cacheMutex.RUnlock()
 
 	result := make([]*dbtypes.BlockBid, 0)
 	for key, bid := range cache.bids {
-		if key.ParentRoot == blockRoot {
+		if key.ParentRoot == blockRoot && phase0.Slot(bid.Slot) == slot {
 			result = append(result, bid)
 		}
 	}

--- a/indexer/beacon/indexer_getter.go
+++ b/indexer/beacon/indexer_getter.go
@@ -521,17 +521,19 @@ func (indexer *Indexer) GetInclusionListsBySlot(slot phase0.Slot) []*v1.SignedIn
 	return indexer.inclusionListCache.getInclusionListsBySlot(slot)
 }
 
-// GetBlockBids returns the execution payload bids for a given parent block root.
+// GetBlockBids returns the execution payload bids for a given parent block root and slot.
 // It first checks the in-memory cache, then falls back to the database.
-func (indexer *Indexer) GetBlockBids(parentBlockRoot phase0.Root) []*dbtypes.BlockBid {
+// Filtering by slot is required because orphaned/skipped predecessor slots share
+// the same parent root as the canonical block that ends up replacing them.
+func (indexer *Indexer) GetBlockBids(parentBlockRoot phase0.Root, slot phase0.Slot) []*dbtypes.BlockBid {
 	// First check the in-memory cache
-	bids := indexer.blockBidCache.GetBidsForBlockRoot(parentBlockRoot)
+	bids := indexer.blockBidCache.GetBidsForBlockRoot(parentBlockRoot, slot)
 	if len(bids) > 0 {
 		return bids
 	}
 
 	// Fall back to database
-	return db.GetBidsForBlockRoot(indexer.ctx, parentBlockRoot[:])
+	return db.GetBidsForBlockRoot(indexer.ctx, parentBlockRoot[:], uint64(slot))
 }
 
 // StreamActiveBuilderDataForRoot streams the available builder set data for a given blockRoot.


### PR DESCRIPTION
## Summary
- The slot page's Bids tab was looking up bids by `ParentRoot` only, so when a slot reorged preceding slots that shared the same parent root, their bids leaked into the current slot's view (e.g. slot 2410 on glamsterdam-devnet-0 was showing 3 bids — the winner plus 2 from orphaned predecessors).
- Filter bids by the bid's own `Slot` field (populated from `SignedExecutionPayloadBid.Message.Slot` in both the SSE handler and the block-derived path) so only bids actually targeting this slot are shown.

## Test plan
- [ ] Visit a slot that reorged a previous slot (e.g. https://dora.glamsterdam-devnet-0.ethpandaops.io/slot/0x3ef298196264b3cb024b41bcd96951bbc066b19905f38ddcb7f42cb7d7631e9b) and confirm only the bids targeting that slot are listed
- [ ] Visit a normal slot and confirm bids still render with the winner highlighted