### PR TITLE
Swap epoch range filter for slot range on Filtered Slots page

### DIFF
--- a/handlers/slots_filtered.go
+++ b/handlers/slots_filtered.go
@@ -62,8 +62,8 @@ func SlotsFiltered(w http.ResponseWriter, r *http.Request) {
 	var minBlobCount string
 	var maxBlobCount string
 	var forkIds string
-	var minEpoch string
-	var maxEpoch string
+	var minSlot string
+	var maxSlot string
 	var builder string
 
 	if urlArgs.Has("f") {
@@ -121,11 +121,11 @@ func SlotsFiltered(w http.ResponseWriter, r *http.Request) {
 		if urlArgs.Has("f.fork") {
 			forkIds = urlArgs.Get("f.fork")
 		}
-		if urlArgs.Has("f.minepoch") {
-			minEpoch = urlArgs.Get("f.minepoch")
+		if urlArgs.Has("f.minslot") {
+			minSlot = urlArgs.Get("f.minslot")
 		}
-		if urlArgs.Has("f.maxepoch") {
-			maxEpoch = urlArgs.Get("f.maxepoch")
+		if urlArgs.Has("f.maxslot") {
+			maxSlot = urlArgs.Get("f.maxslot")
 		}
 		if urlArgs.Has("f.builder") {
 			builder = urlArgs.Get("f.builder")
@@ -134,7 +134,7 @@ func SlotsFiltered(w http.ResponseWriter, r *http.Request) {
 	var pageError error
 	pageError = services.GlobalCallRateLimiter.CheckCallLimit(r, 2)
 	if pageError == nil {
-		data.Data, pageError = getFilteredSlotsPageData(pageIdx, pageSize, graffiti, invertgraffiti, extradata, invertextradata, proposer, pname, invertproposer, uint8(statusMask), uint8(payloadMask), minSyncAgg, maxSyncAgg, minExecTime, maxExecTime, minTxCount, maxTxCount, minBlobCount, maxBlobCount, forkIds, minEpoch, maxEpoch, builder, displayColumns)
+		data.Data, pageError = getFilteredSlotsPageData(pageIdx, pageSize, graffiti, invertgraffiti, extradata, invertextradata, proposer, pname, invertproposer, uint8(statusMask), uint8(payloadMask), minSyncAgg, maxSyncAgg, minExecTime, maxExecTime, minTxCount, maxTxCount, minBlobCount, maxBlobCount, forkIds, minSlot, maxSlot, builder, displayColumns)
 	}
 	if pageError != nil {
 		handlePageError(w, r, pageError)
@@ -146,11 +146,11 @@ func SlotsFiltered(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getFilteredSlotsPageData(pageIdx uint64, pageSize uint64, graffiti string, invertgraffiti bool, extradata string, invertextradata bool, proposer string, pname string, invertproposer bool, statusMask uint8, payloadMask uint8, minSyncAgg string, maxSyncAgg string, minExecTime string, maxExecTime string, minTxCount string, maxTxCount string, minBlobCount string, maxBlobCount string, forkIds string, minEpoch string, maxEpoch string, builder string, displayColumns uint64) (*models.SlotsFilteredPageData, error) {
+func getFilteredSlotsPageData(pageIdx uint64, pageSize uint64, graffiti string, invertgraffiti bool, extradata string, invertextradata bool, proposer string, pname string, invertproposer bool, statusMask uint8, payloadMask uint8, minSyncAgg string, maxSyncAgg string, minExecTime string, maxExecTime string, minTxCount string, maxTxCount string, minBlobCount string, maxBlobCount string, forkIds string, minSlot string, maxSlot string, builder string, displayColumns uint64) (*models.SlotsFilteredPageData, error) {
 	pageData := &models.SlotsFilteredPageData{}
-	pageCacheKey := fmt.Sprintf("slots_filtered:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v", pageIdx, pageSize, graffiti, invertgraffiti, extradata, invertextradata, proposer, pname, invertproposer, statusMask, payloadMask, minSyncAgg, maxSyncAgg, minExecTime, maxExecTime, minTxCount, maxTxCount, minBlobCount, maxBlobCount, forkIds, minEpoch, maxEpoch, builder, displayColumns)
+	pageCacheKey := fmt.Sprintf("slots_filtered:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v", pageIdx, pageSize, graffiti, invertgraffiti, extradata, invertextradata, proposer, pname, invertproposer, statusMask, payloadMask, minSyncAgg, maxSyncAgg, minExecTime, maxExecTime, minTxCount, maxTxCount, minBlobCount, maxBlobCount, forkIds, minSlot, maxSlot, builder, displayColumns)
 	pageRes, pageErr := services.GlobalFrontendCache.ProcessCachedPage(pageCacheKey, true, pageData, func(pageCall *services.FrontendCacheProcessingPage) interface{} {
-		return buildFilteredSlotsPageData(pageCall.CallCtx, pageIdx, pageSize, graffiti, invertgraffiti, extradata, invertextradata, proposer, pname, invertproposer, statusMask, payloadMask, minSyncAgg, maxSyncAgg, minExecTime, maxExecTime, minTxCount, maxTxCount, minBlobCount, maxBlobCount, forkIds, minEpoch, maxEpoch, builder, displayColumns)
+		return buildFilteredSlotsPageData(pageCall.CallCtx, pageIdx, pageSize, graffiti, invertgraffiti, extradata, invertextradata, proposer, pname, invertproposer, statusMask, payloadMask, minSyncAgg, maxSyncAgg, minExecTime, maxExecTime, minTxCount, maxTxCount, minBlobCount, maxBlobCount, forkIds, minSlot, maxSlot, builder, displayColumns)
 	})
 	if pageErr == nil && pageRes != nil {
 		resData, resOk := pageRes.(*models.SlotsFilteredPageData)
@@ -162,7 +162,7 @@ func getFilteredSlotsPageData(pageIdx uint64, pageSize uint64, graffiti string, 
 	return pageData, pageErr
 }
 
-func buildFilteredSlotsPageData(ctx context.Context, pageIdx uint64, pageSize uint64, graffiti string, invertgraffiti bool, extradata string, invertextradata bool, proposer string, pname string, invertproposer bool, statusMask uint8, payloadMask uint8, minSyncAgg string, maxSyncAgg string, minExecTime string, maxExecTime string, minTxCount string, maxTxCount string, minBlobCount string, maxBlobCount string, forkIds string, minEpoch string, maxEpoch string, builder string, displayColumns uint64) *models.SlotsFilteredPageData {
+func buildFilteredSlotsPageData(ctx context.Context, pageIdx uint64, pageSize uint64, graffiti string, invertgraffiti bool, extradata string, invertextradata bool, proposer string, pname string, invertproposer bool, statusMask uint8, payloadMask uint8, minSyncAgg string, maxSyncAgg string, minExecTime string, maxExecTime string, minTxCount string, maxTxCount string, minBlobCount string, maxBlobCount string, forkIds string, minSlot string, maxSlot string, builder string, displayColumns uint64) *models.SlotsFilteredPageData {
 	chainState := services.GlobalBeaconService.GetChainState()
 	filterArgs := url.Values{}
 	if graffiti != "" {
@@ -219,11 +219,11 @@ func buildFilteredSlotsPageData(ctx context.Context, pageIdx uint64, pageSize ui
 	if forkIds != "" {
 		filterArgs.Add("f.fork", forkIds)
 	}
-	if minEpoch != "" {
-		filterArgs.Add("f.minepoch", minEpoch)
+	if minSlot != "" {
+		filterArgs.Add("f.minslot", minSlot)
 	}
-	if maxEpoch != "" {
-		filterArgs.Add("f.maxepoch", maxEpoch)
+	if maxSlot != "" {
+		filterArgs.Add("f.maxslot", maxSlot)
 	}
 	if builder != "" {
 		filterArgs.Add("f.builder", builder)
@@ -319,8 +319,8 @@ func buildFilteredSlotsPageData(ctx context.Context, pageIdx uint64, pageSize ui
 		FilterMinBlobCount:     minBlobCount,
 		FilterMaxBlobCount:     maxBlobCount,
 		FilterForkIds:          forkIds,
-		FilterMinEpoch:         minEpoch,
-		FilterMaxEpoch:         maxEpoch,
+		FilterMinSlot:          minSlot,
+		FilterMaxSlot:          maxSlot,
 		FilterBuilder:          builder,
 
 		DisplayEpoch:        displayMap[1],
@@ -456,16 +456,16 @@ func buildFilteredSlotsPageData(ctx context.Context, pageIdx uint64, pageSize ui
 			blockFilter.ForkIds = parsedForkIds
 		}
 	}
-	if minEpoch != "" {
-		minEp, err := strconv.ParseUint(minEpoch, 10, 64)
+	if minSlot != "" {
+		minSl, err := strconv.ParseUint(minSlot, 10, 64)
 		if err == nil {
-			blockFilter.MinEpoch = &minEp
+			blockFilter.MinSlot = &minSl
 		}
 	}
-	if maxEpoch != "" {
-		maxEp, err := strconv.ParseUint(maxEpoch, 10, 64)
+	if maxSlot != "" {
+		maxSl, err := strconv.ParseUint(maxSlot, 10, 64)
 		if err == nil {
-			blockFilter.MaxEpoch = &maxEp
+			blockFilter.MaxSlot = &maxSl
 		}
 	}
 	if builder != "" {

--- a/templates/slots_filtered/slots_filtered.html
+++ b/templates/slots_filtered/slots_filtered.html
@@ -74,17 +74,17 @@
                 </div>
                 <div class="row mt-1">
                   <div class="col-sm-12 col-md-6 col-lg-4">
-                    <nobr>Epoch</nobr>
+                    <nobr>Slot</nobr>
                   </div>
                   <div class="col-sm-12 col-md-6 col-lg-8 d-flex">
                     <div class="flex-grow-1">
-                      <input name="f.minepoch" type="number" class="form-control" placeholder="Min" aria-label="Min Epoch" min="0" value="{{ .FilterMinEpoch }}">
+                      <input name="f.minslot" type="number" class="form-control" placeholder="Min" aria-label="Min Slot" min="0" value="{{ .FilterMinSlot }}">
                     </div>
                     <div class="text-center filter-separator">
                       -
                     </div>
                     <div class="flex-grow-1">
-                      <input name="f.maxepoch" type="number" class="form-control" placeholder="Max" aria-label="Max Epoch" min="0" value="{{ .FilterMaxEpoch }}">
+                      <input name="f.maxslot" type="number" class="form-control" placeholder="Max" aria-label="Max Slot" min="0" value="{{ .FilterMaxSlot }}">
                     </div>
                     <div class="text-center" style="width: 30px;">
 

--- a/types/models/slots_filtered.go
+++ b/types/models/slots_filtered.go
@@ -28,8 +28,8 @@ type SlotsFilteredPageData struct {
 	FilterMinBlobCount     string `json:"filter_min_blob"`
 	FilterMaxBlobCount     string `json:"filter_max_blob"`
 	FilterForkIds          string `json:"filter_fork_ids"`
-	FilterMinEpoch         string `json:"filter_min_epoch"`
-	FilterMaxEpoch         string `json:"filter_max_epoch"`
+	FilterMinSlot          string `json:"filter_min_slot"`
+	FilterMaxSlot          string `json:"filter_max_slot"`
 	FilterBuilder          string `json:"filter_builder"`
 
 	DisplayEpoch        bool   `json:"dp_epoch"`


### PR DESCRIPTION
## Summary
- The Filtered Slots page (`/slots/filtered`) now exposes a **Slot** min/max range filter instead of the previous **Epoch** range. Users typically want to inspect a specific slot range, so binding directly to slots removes the round-trip through epoch→slot conversion.
- Form fields renamed: `f.minepoch`/`f.maxepoch` → `f.minslot`/`f.maxslot`.
- Backend now sets `BlockFilter.MinSlot`/`MaxSlot` directly (these are the canonical fields the DB query already uses).
- Model fields `FilterMinEpoch`/`FilterMaxEpoch` → `FilterMinSlot`/`FilterMaxSlot`.
- The Filtered Blocks page is intentionally untouched — only the Filtered Slots page is changed.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass.
- [x] Ran dora locally against a public mainnet beacon endpoint and verified at `/slots/filtered`:
  - Form renders with **Slot** label and `f.minslot`/`f.maxslot` inputs.
  - `?f.minslot=14220250&f.maxslot=14220290` returns exactly the 41 slots in that inclusive range.
  - `?f.minslot=14220270&f.maxslot=14220280` returns exactly 11 slots.
  - Bookmarks using legacy `f.minepoch`/`f.maxepoch` params are silently ignored — page renders with empty slot range and unfiltered results.