### PR TITLE
feat(chainspec): add gloas EIP-8061 churn limits and heze INCLUSION_LIST_DUE_BPS

### DIFF
--- a/clients/consensus/chainspec.go
+++ b/clients/consensus/chainspec.go
@@ -119,7 +119,10 @@ type ChainSpecConfig struct {
 	BlobSchedule                     []BlobScheduleEntry `yaml:"BLOB_SCHEDULE"                                 check-if-fork:"FuluForkEpoch"`
 
 	// Gloas
-	MinBuilderWithdrawabilityDelay uint64 `yaml:"MIN_BUILDER_WITHDRAWABILITY_DELAY" check-if-fork:"GloasForkEpoch"`
+	MinBuilderWithdrawabilityDelay       uint64 `yaml:"MIN_BUILDER_WITHDRAWABILITY_DELAY"          check-if-fork:"GloasForkEpoch"`
+	ChurnLimitQuotientGloas              uint64 `yaml:"CHURN_LIMIT_QUOTIENT_GLOAS"                 check-if-fork:"GloasForkEpoch"`
+	ConsolidationChurnLimitQuotient      uint64 `yaml:"CONSOLIDATION_CHURN_LIMIT_QUOTIENT"         check-if-fork:"GloasForkEpoch"`
+	MaxPerEpochActivationChurnLimitGloas uint64 `yaml:"MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT_GLOAS" check-if-fork:"GloasForkEpoch"`
 }
 
 type ChainSpecPreset struct {

--- a/clients/consensus/chainspec.go
+++ b/clients/consensus/chainspec.go
@@ -123,6 +123,9 @@ type ChainSpecConfig struct {
 	ChurnLimitQuotientGloas              uint64 `yaml:"CHURN_LIMIT_QUOTIENT_GLOAS"                 check-if-fork:"GloasForkEpoch"`
 	ConsolidationChurnLimitQuotient      uint64 `yaml:"CONSOLIDATION_CHURN_LIMIT_QUOTIENT"         check-if-fork:"GloasForkEpoch"`
 	MaxPerEpochActivationChurnLimitGloas uint64 `yaml:"MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT_GLOAS" check-if-fork:"GloasForkEpoch"`
+
+	// Heze
+	InclusionListDueBPS uint64 `yaml:"INCLUSION_LIST_DUE_BPS" check-if-fork:"HezeForkEpoch"`
 }
 
 type ChainSpecPreset struct {


### PR DESCRIPTION
## Summary
Brings dora's \`ChainSpec\` parser up to consensus-specs **v1.7.0-alpha.7**, covering everything that landed between alpha 5 and alpha 7.

### Gloas — new EIP-8061 churn limits ([#5061](https://github.com/ethereum/consensus-specs/pull/5061))
Added to \`ChainSpecConfig\`, all gated on \`GloasForkEpoch\`:
- \`CHURN_LIMIT_QUOTIENT_GLOAS\` (mainnet 32768 / minimal 16)
- \`CONSOLIDATION_CHURN_LIMIT_QUOTIENT\` (mainnet 65536 / minimal 32)
- \`MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT_GLOAS\` (mainnet 256e9 / minimal 128e9 Gwei)

### Heze — inclusion list deadline rename ([#5138](https://github.com/ethereum/consensus-specs/pull/5138))
Alpha 7 collapses three Heze BPS values into a single one. None of the old three fields existed in dora, so this is purely additive:
- \`INCLUSION_LIST_DUE_BPS\` (gated on \`HezeForkEpoch\`)

### Not changed (intentionally)
The minimal preset \`PTC_SIZE\` bumped from 2 to 16 in alpha 6 ([#5177](https://github.com/ethereum/consensus-specs/pull/5177)), but dora reads \`PTC_SIZE\` dynamically from the connected node's spec — no code change needed for the value bump.

## Companion changes
- [ethpandaops/go-eth2-client#18](https://github.com/ethpandaops/go-eth2-client/pull/18) — adds \`ProposerPreferences.dependent_root\` (alpha 7 rename of \`checkpoint_root\`).
- [OffchainLabs/go-bitfield#67](https://github.com/OffchainLabs/go-bitfield/pull/67) — \`Bitvector16\`, the natural Go type for the new minimal-preset PTC committee size.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./clients/...\`
- [ ] Smoke-test against a Gloas devnet node (alpha 6+) and confirm no \`unknown spec field\` warnings