### PR TITLE
db: SQLite pragma tuning + chunk GetDepositTxsByIndexes

### DIFF
--- a/db/common.go
+++ b/db/common.go
@@ -74,7 +74,20 @@ func mustInitSqlite(config *types.SqliteDatabaseConfig) (*sqlx.DB, *sqlx.DB) {
 	dbConn.SetMaxOpenConns(config.MaxOpenConns)
 	dbConn.SetMaxIdleConns(config.MaxIdleConns)
 
+	// WAL journaling allows readers to run during writes.
 	dbConn.MustExec("PRAGMA journal_mode = WAL")
+	// synchronous=NORMAL is durable in WAL mode (only the last committed
+	// transaction is at risk on power loss; DB stays consistent) and is
+	// substantially faster than the default FULL because it skips an fsync
+	// per commit.
+	dbConn.MustExec("PRAGMA synchronous = NORMAL")
+	// 256 MB page cache. Default is ~2 MB, which causes heavy churn on
+	// blocks with many log/tx rows (e.g. high-deposit blocks).
+	dbConn.MustExec("PRAGMA cache_size = -262144")
+	// Keep transient tables/indexes used by query planners in memory.
+	dbConn.MustExec("PRAGMA temp_store = MEMORY")
+	// Wait up to 5s for a competing writer instead of failing immediately.
+	dbConn.MustExec("PRAGMA busy_timeout = 5000")
 
 	return dbConn, dbConn
 }

--- a/db/deposit_txs.go
+++ b/db/deposit_txs.go
@@ -100,24 +100,40 @@ func GetDepositTxsByIndexes(ctx context.Context, indexes []uint64) []*dbtypes.De
 		return depositTxs
 	}
 
-	var sql strings.Builder
-	args := make([]any, len(indexes))
+	// SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999 (32766 in newer
+	// builds). Chunk to stay well below that on every supported build,
+	// otherwise high-deposit-volume queries fail with
+	// "too many SQL variables".
+	const maxParams = 900
 
-	fmt.Fprint(&sql, `SELECT deposit_txs.*
-		FROM deposit_txs
-		WHERE deposit_index IN (
-	`)
+	for start := 0; start < len(indexes); start += maxParams {
+		end := start + maxParams
+		if end > len(indexes) {
+			end = len(indexes)
+		}
+		chunk := indexes[start:end]
 
-	for idx, index := range indexes {
-		args[idx] = index
-	}
-	appendDollarPlaceholders(&sql, 1, len(indexes), ", ")
-	fmt.Fprintf(&sql, ")")
+		var sql strings.Builder
+		args := make([]any, len(chunk))
 
-	err := ReaderDb.SelectContext(ctx, &depositTxs, sql.String(), args...)
-	if err != nil {
-		logger.Errorf("Error while fetching deposit txs by indexes: %v", err)
-		return nil
+		fmt.Fprint(&sql, `SELECT deposit_txs.*
+			FROM deposit_txs
+			WHERE deposit_index IN (
+		`)
+
+		for idx, index := range chunk {
+			args[idx] = index
+		}
+		appendDollarPlaceholders(&sql, 1, len(chunk), ", ")
+		fmt.Fprintf(&sql, ")")
+
+		var chunkResult []*dbtypes.DepositTx
+		err := ReaderDb.SelectContext(ctx, &chunkResult, sql.String(), args...)
+		if err != nil {
+			logger.Errorf("Error while fetching deposit txs by indexes: %v", err)
+			return nil
+		}
+		depositTxs = append(depositTxs, chunkResult...)
 	}
 
 	return depositTxs


### PR DESCRIPTION
Two small, independent SQLite-backend fixes. Postgres is unaffected.

## 1. Pragma tuning alongside WAL

WAL was already enabled, but `synchronous`, `cache_size`, and `temp_store` were left at their defaults — so every commit still fsyncs the WAL and the 2 MB default page cache churns on any write-heavy block. Set standard values:

- `synchronous = NORMAL` — safe under WAL (only the most recent commit is at risk on power loss; the DB stays consistent), avoids one fsync per commit.
- `cache_size = -262144` — 256 MB page cache.
- `temp_store = MEMORY` — keeps planner-internal tables off disk.
- `busy_timeout = 5000` — wait up to 5s for a competing writer instead of failing immediately.

No behavior change beyond throughput and contention.

## 2. Chunk `GetDepositTxsByIndexes` to stay under `SQLITE_MAX_VARIABLE_NUMBER`

`GetDepositTxsByIndexes` builds a single `WHERE deposit_index IN ($1, $2, ..., $N)` with one placeholder per requested index. SQLite's default `SQLITE_MAX_VARIABLE_NUMBER` is 999 in older builds (32766 in newer), so once the caller passes more than ~999 indexes the query fails outright with `too many SQL variables`.

This is a correctness bug, not a perf bug — the query crashes. It's reachable on any network with a long pending-deposit queue or any future API path that walks a large index list. It surfaced in practice on a high-deposit-rate devnet:

```
Error while fetching deposit txs by indexes:
  SQL logic error: too many SQL variables (1)
```

Chunk the input into batches of 900 (well under the lower SQLite limit) and concatenate results. Behavior is unchanged for inputs below the threshold.

## What this PR does *not* claim to fix

It does **not** fix the heavier issue of dora's tx-indexer falling behind on blocks with thousands of `DepositEvent` logs (e.g. an EIP-8254-style 8192-deposit-per-block stress test). That root cause is the volume of rows inserted per block (8192 events + ~70K internal-call rows per block × multiple secondary indexes) hitting the throughput ceiling of the pure-Go SQLite engine. Real fixes there would require either restructuring the per-block insert pattern, or accepting the CGO complexity of `mattn/go-sqlite3`, or moving the hot path off SQL — all out of scope here. Production deployments use Postgres and don't have this issue.

## Test plan
- [ ] Existing tests still pass on SQLite and Postgres backends.
- [ ] `GetDepositTxsByIndexes` returns the same set whether called with 100, 999, 1000, or 5000 indexes (manual sanity check on a populated DB).