### PR TITLE
fix: link Builder column on slot Bids tab to /builder/<idx>

### DIFF
--- a/templates/slot/bids.html
+++ b/templates/slot/bids.html
@@ -17,9 +17,9 @@
           <tr{{ if $bid.IsWinning }} style="border-left: 3px solid var(--bs-success);"{{ end }}>
             <td>
               {{ if $bid.IsSelfBuilt }}
-                <span class="validator-label validator-index"><i class="fas fa-male mr-2"></i> Self-built</span>
+                <span class="builder-label builder-index"><i class="fas fa-hard-hat mr-2"></i> Self-built</span>
               {{ else }}
-                {{ formatValidatorWithIndex $bid.BuilderIndex $bid.BuilderName }}
+                {{ formatBuilderWithIndex $bid.BuilderIndex $bid.BuilderName }}
               {{ end }}
               {{ if $bid.IsWinning }}<span class="badge bg-success ms-1">Winner</span>{{ end }}
             </td>


### PR DESCRIPTION
## Summary
- The Builder column on the slot Bids tab was using `formatValidatorWithIndex`, which renders an `<a href=\"/validator/{index}\">`. Builder and validator indices live in separate pools, so the link pointed at the wrong entity (e.g. builder `0` was linking to validator `0`).
- Switched to the existing `formatBuilderWithIndex` helper (`utils/format.go:846`) so the link goes to `/builder/{index}`.
- Updated the Self-built badge to use `builder-label`/`builder-index` classes and the `fa-hard-hat` icon for visual consistency with the rest of the builder UI.

Reported on https://dora.glamsterdam-devnet-3.ethpandaops.io/slot/4869 (Bids tab).

## Test plan
- [ ] Open a slot with bids (e.g. glamsterdam-devnet-3 slot 4869) and verify the Builder cell links to `/builder/<idx>` and lands on the Builder details page.
- [ ] Verify a self-built bid shows the "Self-built" badge with the hard-hat icon and no broken link.
- [ ] Confirm the winner highlighting and other columns are unchanged.