### PR TITLE
fix: render BAL tx details From/To as hex instead of base64

### DIFF
--- a/templates/slot/block_access_list.html
+++ b/templates/slot/block_access_list.html
@@ -1833,13 +1833,13 @@
           </div>
           <div class="tx-callout-row">
             <span class="tx-callout-label">From:</span>
-            <span class="tx-callout-value">${tx.from}</span>
-            <i class="fa fa-copy tx-callout-copy" onclick="copyToClipboard('${tx.from}')" title="Copy to clipboard"></i>
+            <span class="tx-callout-value">0x${bytesToHex(tx.from)}</span>
+            <i class="fa fa-copy tx-callout-copy" onclick="copyToClipboard('0x${bytesToHex(tx.from)}')" title="Copy to clipboard"></i>
           </div>
           <div class="tx-callout-row">
             <span class="tx-callout-label">To:</span>
-            <span class="tx-callout-value">${tx.to}</span>
-            <i class="fa fa-copy tx-callout-copy" onclick="copyToClipboard('${tx.to}')" title="Copy to clipboard"></i>
+            <span class="tx-callout-value">${tx.to ? `0x${bytesToHex(tx.to)}` : 'Contract Creation'}</span>
+            ${tx.to ? `<i class="fa fa-copy tx-callout-copy" onclick="copyToClipboard('0x${bytesToHex(tx.to)}')" title="Copy to clipboard"></i>` : ''}
           </div>
           <div class="tx-callout-row">
             <span class="tx-callout-label">Value:</span>


### PR DESCRIPTION
## Summary
- Block Access List (EIP-7928) transaction details popup was rendering `From`/`To` as raw base64 (e.g. `AwAv3ffRJWGutvgmJcES4r7DT0s=`) because the Go struct fields are `[]byte`, which Go's JSON marshaller base64-encodes by default.
- Pass `tx.from`/`tx.to` through the existing `bytesToHex` helper with a `0x` prefix, matching how `Hash` is already rendered.
- When `To` is null (contract creation), display "Contract Creation" and hide the copy icon.

Before: 
<img width="1734" height="387" alt="Screenshot 2026-05-07 at 10 38 39" src="https://github.com/user-attachments/assets/e34a227d-0f8a-48a5-9f3d-84d196781966" />

After:
<img width="1215" height="529" alt="Screenshot 2026-05-07 at 10 48 13" src="https://github.com/user-attachments/assets/d11bce58-17ef-4b11-a1fb-0b14f4b3c8e0" />


## Test plan
- [ ] Open a slot's Access List tab on a devnet with EIP-7928 data (e.g. glamsterdam-devnet-3 slot 5062)
- [ ] Hover the `Tx <n>` badge on a BAL entry and confirm From/To are now `0x...` hex addresses
- [ ] Copy-to-clipboard yields the same hex string
- [ ] Hash continues to render correctly
- [ ] Contract-creation tx (no `To`) shows "Contract Creation"