### PR TITLE
fix: 404 on unknown slot, plus inclusion-list tx matching on gloas+

### DIFF
--- a/handlers/api/slot_block_access_list_v1.go
+++ b/handlers/api/slot_block_access_list_v1.go
@@ -1,12 +1,9 @@
 package api
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
-	"strings"
 
 	"github.com/ethpandaops/dora/services"
 	"github.com/ethpandaops/dora/utils"
@@ -84,50 +81,30 @@ type APISlotBlockAccessListCode struct {
 func APISlotBlockAccessListV1(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	slotOrHash := mux.Vars(r)["slotOrHash"]
-
-	var (
-		blockRoot phase0.Root
-		slotNum   *uint64
-	)
-
-	if strings.HasPrefix(slotOrHash, "0x") && len(slotOrHash) == 66 {
-		rootBytes, err := hex.DecodeString(strings.TrimPrefix(slotOrHash, "0x"))
-		if err != nil {
-			http.Error(w, `{"status": "ERROR: invalid root format"}`, http.StatusBadRequest)
-			return
-		}
-		copy(blockRoot[:], rootBytes)
-	} else {
-		parsed, err := strconv.ParseUint(slotOrHash, 10, 64)
-		if err != nil {
-			http.Error(w, `{"status": "ERROR: invalid slot number or root format"}`, http.StatusBadRequest)
-			return
-		}
-		slotNum = &parsed
+	// First confirm the slot exists in the indexer (clean 404 on miss). Going
+	// straight to GetSlotDetailsByBlockroot for an unknown root surfaces a
+	// "no clients available" error from beacon header loading and turns into a
+	// 500 instead of a 404.
+	dbSlot := resolveSlotOrHash(r.Context(), w, mux.Vars(r)["slotOrHash"])
+	if dbSlot == nil {
+		return
 	}
 
-	var (
-		blockData *services.CombinedBlockResponse
-		err       error
-	)
-	if slotNum != nil {
-		blockData, err = services.GlobalBeaconService.GetSlotDetailsBySlot(r.Context(), phase0.Slot(*slotNum))
-	} else {
-		blockData, err = services.GlobalBeaconService.GetSlotDetailsByBlockroot(r.Context(), blockRoot)
-	}
+	var resolvedRoot phase0.Root
+	copy(resolvedRoot[:], dbSlot.Root)
+	resolvedSlot := dbSlot.Slot
+
+	blockData, err := services.GlobalBeaconService.GetSlotDetailsByBlockroot(r.Context(), resolvedRoot)
 	if err != nil {
 		logrus.WithError(err).Error("failed to load slot details")
 		http.Error(w, `{"status": "ERROR: failed to load slot details"}`, http.StatusInternalServerError)
 		return
 	}
-	if blockData == nil || blockData.Header == nil {
-		http.Error(w, `{"status": "ERROR: slot not found"}`, http.StatusNotFound)
+	if blockData == nil {
+		// Indexer knows the slot but block details aren't loadable — treat as missing.
+		writeBALResponse(w, resolvedSlot, resolvedRoot[:], nil)
 		return
 	}
-
-	resolvedRoot := blockData.Root
-	resolvedSlot := uint64(blockData.Header.Message.Slot)
 
 	if len(blockData.BlockAccessList) == 0 {
 		// No BAL is a valid response (pre-fulu / pre-7928 blocks). Return empty list.

--- a/handlers/api/slot_payload_header_v1.go
+++ b/handlers/api/slot_payload_header_v1.go
@@ -2,13 +2,10 @@ package api
 
 import (
 	"bytes"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
-	"strconv"
-	"strings"
 
 	"github.com/ethpandaops/dora/dbtypes"
 	"github.com/ethpandaops/dora/services"
@@ -60,52 +57,31 @@ type APISlotPayloadHeaderData struct {
 func APISlotPayloadHeaderV1(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	slotOrHash := mux.Vars(r)["slotOrHash"]
-
-	var (
-		blockRoot phase0.Root
-		slotNum   *uint64
-	)
-
-	if strings.HasPrefix(slotOrHash, "0x") && len(slotOrHash) == 66 {
-		rootBytes, err := hex.DecodeString(strings.TrimPrefix(slotOrHash, "0x"))
-		if err != nil {
-			http.Error(w, `{"status": "ERROR: invalid root format"}`, http.StatusBadRequest)
-			return
-		}
-		copy(blockRoot[:], rootBytes)
-	} else {
-		parsed, err := strconv.ParseUint(slotOrHash, 10, 64)
-		if err != nil {
-			http.Error(w, `{"status": "ERROR: invalid slot number or root format"}`, http.StatusBadRequest)
-			return
-		}
-		slotNum = &parsed
+	// Resolve through the indexer first so unknown slots/roots return 404
+	// instead of bubbling up a 500 from beacon header loading.
+	dbSlot := resolveSlotOrHash(r.Context(), w, mux.Vars(r)["slotOrHash"])
+	if dbSlot == nil {
+		return
 	}
 
-	var (
-		blockData *services.CombinedBlockResponse
-		err       error
-	)
-	if slotNum != nil {
-		blockData, err = services.GlobalBeaconService.GetSlotDetailsBySlot(r.Context(), phase0.Slot(*slotNum))
-	} else {
-		blockData, err = services.GlobalBeaconService.GetSlotDetailsByBlockroot(r.Context(), blockRoot)
+	var resolvedRoot phase0.Root
+	copy(resolvedRoot[:], dbSlot.Root)
+
+	data := &APISlotPayloadHeaderData{
+		Slot:              dbSlot.Slot,
+		BlockRoot:         fmt.Sprintf("0x%x", dbSlot.Root),
+		PayloadStatusName: payloadStatusName(dbtypes.PayloadStatusMissing),
 	}
+
+	blockData, err := services.GlobalBeaconService.GetSlotDetailsByBlockroot(r.Context(), resolvedRoot)
 	if err != nil {
 		logrus.WithError(err).Error("failed to load slot details")
 		http.Error(w, `{"status": "ERROR: failed to load slot details"}`, http.StatusInternalServerError)
 		return
 	}
-	if blockData == nil || blockData.Header == nil || blockData.Block == nil {
-		http.Error(w, `{"status": "ERROR: slot not found"}`, http.StatusNotFound)
+	if blockData == nil || blockData.Block == nil {
+		writePayloadHeaderResponse(w, data)
 		return
-	}
-
-	data := &APISlotPayloadHeaderData{
-		Slot:              uint64(blockData.Header.Message.Slot),
-		BlockRoot:         fmt.Sprintf("0x%x", blockData.Root[:]),
-		PayloadStatusName: payloadStatusName(dbtypes.PayloadStatusMissing),
 	}
 
 	if blockData.Block.Version < spec.DataVersionGloas {

--- a/handlers/api/slot_ptc_votes_v1.go
+++ b/handlers/api/slot_ptc_votes_v1.go
@@ -1,12 +1,9 @@
 package api
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
-	"strings"
 
 	"github.com/ethpandaops/dora/services"
 	"github.com/ethpandaops/go-eth2-client/spec"
@@ -70,55 +67,33 @@ type APISlotPtcValidator struct {
 func APISlotPtcVotesV1(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	slotOrHash := mux.Vars(r)["slotOrHash"]
-
-	var (
-		blockRoot phase0.Root
-		slotNum   *uint64
-	)
-
-	if strings.HasPrefix(slotOrHash, "0x") && len(slotOrHash) == 66 {
-		rootBytes, err := hex.DecodeString(strings.TrimPrefix(slotOrHash, "0x"))
-		if err != nil {
-			http.Error(w, `{"status": "ERROR: invalid root format"}`, http.StatusBadRequest)
-			return
-		}
-		copy(blockRoot[:], rootBytes)
-	} else {
-		parsed, err := strconv.ParseUint(slotOrHash, 10, 64)
-		if err != nil {
-			http.Error(w, `{"status": "ERROR: invalid slot number or root format"}`, http.StatusBadRequest)
-			return
-		}
-		slotNum = &parsed
+	// Resolve through the indexer first so unknown slots/roots return 404
+	// instead of bubbling up a 500 from beacon header loading.
+	dbSlot := resolveSlotOrHash(r.Context(), w, mux.Vars(r)["slotOrHash"])
+	if dbSlot == nil {
+		return
 	}
 
-	var (
-		blockData *services.CombinedBlockResponse
-		err       error
-	)
-	if slotNum != nil {
-		blockData, err = services.GlobalBeaconService.GetSlotDetailsBySlot(r.Context(), phase0.Slot(*slotNum))
-	} else {
-		blockData, err = services.GlobalBeaconService.GetSlotDetailsByBlockroot(r.Context(), blockRoot)
+	var resolvedRoot phase0.Root
+	copy(resolvedRoot[:], dbSlot.Root)
+	resolvedSlot := phase0.Slot(dbSlot.Slot)
+
+	data := &APISlotPtcVotesData{
+		Slot:       uint64(resolvedSlot),
+		BlockRoot:  fmt.Sprintf("0x%x", dbSlot.Root),
+		Aggregates: []*APISlotPtcAggregate{},
+		NonVoters:  []APISlotPtcValidator{},
 	}
+
+	blockData, err := services.GlobalBeaconService.GetSlotDetailsByBlockroot(r.Context(), resolvedRoot)
 	if err != nil {
 		logrus.WithError(err).Error("failed to load slot details")
 		http.Error(w, `{"status": "ERROR: failed to load slot details"}`, http.StatusInternalServerError)
 		return
 	}
-	if blockData == nil || blockData.Header == nil || blockData.Block == nil {
-		http.Error(w, `{"status": "ERROR: slot not found"}`, http.StatusNotFound)
+	if blockData == nil || blockData.Block == nil {
+		writePtcVotesResponse(w, data)
 		return
-	}
-
-	resolvedSlot := blockData.Header.Message.Slot
-
-	data := &APISlotPtcVotesData{
-		Slot:       uint64(resolvedSlot),
-		BlockRoot:  fmt.Sprintf("0x%x", blockData.Root[:]),
-		Aggregates: []*APISlotPtcAggregate{},
-		NonVoters:  []APISlotPtcValidator{},
 	}
 
 	if blockData.Block.Version < spec.DataVersionGloas {


### PR DESCRIPTION
Stacked on #686. Two unrelated bug fixes against the new gloas slot endpoints, both found while testing #686.

## 1. 500 → 404 on unknown slot for BAL / ptc_votes / payload_header
These endpoints went straight to `GetSlotDetailsByBlockroot`, which on a miss falls through to beacon-client header loading and surfaces a "no clients available" / load error. Result: HTTP 500 for an unknown root.

Fix: resolve through the indexer first via the existing `resolveSlotOrHash` helper (same pattern as the `bids` endpoint). Unknown slots/roots get a clean 404; genuine load errors after a successful resolve still return 500.

## 2. inclusion_lists `is_included` always false on gloas+
`VersionedSignedBeaconBlock.ExecutionPayload()` returns "no execution payload in gloas/heze" because the payload moved to a separate `SignedExecutionPayloadEnvelope` in EIP-7732. The handler silently swallowed that error and never populated the block-tx-hash set, so every IL transaction was reported `is_included: false` on gloas/heze blocks.

Fix: mirror the slot-page logic — for gloas+ blocks, construct the `VersionedExecutionPayload` from `blockData.Payload.Message.Payload` before calling `Transactions()`.

## Test plan
- [ ] `curl /v1/slot/0x0000…0000/block_access_list` → 404 (was 500).
- [ ] `curl /v1/slot/0x0000…0000/ptc_votes` → 404.
- [ ] `curl /v1/slot/0x0000…0000/payload_header` → 404.
- [ ] Same endpoints with a valid slot/root still return 200 with the same payload as before.
- [ ] Malformed input (`notaslot`, `0xabcd`, non-hex chars in `0x...`) → 400.
- [ ] On a gloas slot with both an inclusion list and the listed tx in the block, `inclusion_lists[*].transactions[*].is_included` correctly reflects inclusion (was always false before).