### PR TITLE
chore(deps): bump eth-das-guardian to v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/ethereum/go-ethereum v1.17.2
-	github.com/ethpandaops/eth-das-guardian v0.1.0
+	github.com/ethpandaops/eth-das-guardian v0.1.1
 	github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c
 	github.com/ethpandaops/ethwallclock v0.4.0
 	github.com/ethpandaops/go-eth2-client v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJ
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1:IuLm4IsPipXKF7CW5Lzf68PIbZ5yl7FFd74l/E0o9A8=
 github.com/ethereum/go-ethereum v1.17.2 h1:ag6geu0kn8Hv5FLKTpH+Hm2DHD+iuFtuqKxEuwUsDOI=
 github.com/ethereum/go-ethereum v1.17.2/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
-github.com/ethpandaops/eth-das-guardian v0.1.0 h1:pEiRvtzPdF2xMjhiA/i+zmxIKd4uCsOTWxESa55zaJk=
-github.com/ethpandaops/eth-das-guardian v0.1.0/go.mod h1:7amdK4bN9N9Zp0b9Y9FcbDm1YrpeGBm8ix8qpiX0WuY=
+github.com/ethpandaops/eth-das-guardian v0.1.1 h1:RN96h3HSAMyU4XUOCqkj/9+lB+UW7cVW4Wr4JzdjmZY=
+github.com/ethpandaops/eth-das-guardian v0.1.1/go.mod h1:7amdK4bN9N9Zp0b9Y9FcbDm1YrpeGBm8ix8qpiX0WuY=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c h1:uBRIitwcuCJlRGioqm0jQRIojiH8DSyLRFSTCCBxN6o=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c/go.mod h1:QsmYTdesob+vQ6pW4KtRVvxLZUNop3cdtd/DgD30hJU=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=


### PR DESCRIPTION
## Summary

- The \`github.com/ethpandaops/eth-das-guardian@v0.1.0\` entry in [sum.golang.org](https://sum.golang.org/lookup/github.com/ethpandaops/eth-das-guardian@v0.1.0) was poisoned during the original release on 2026-04-14: a failed \`Build Release\` workflow run created the \`v0.1.0\` tag, the sum DB indexed its content, and a subsequent retry force-moved the tag to a different commit. The sum DB record is immutable, so any fresh \`go mod download\` (e.g. clean Docker build) hits a checksum mismatch:
  \`\`\`
  verifying github.com/ethpandaops/eth-das-guardian@v0.1.0: checksum mismatch
      downloaded: h1:r5pZ1eHHskZJ9JGSbp0E3u2pAI/loAC4q+u+Y58h7SY=
      go.sum:     h1:pEiRvtzPdF2xMjhiA/i+zmxIKd4uCsOTWxESa55zaJk=
  \`\`\`
- Cut \`v0.1.1\` from current main of [ethpandaops/eth-das-guardian](https://github.com/ethpandaops/eth-das-guardian/releases/tag/v0.1.1) (no code changes vs the intended v0.1.0 content) and bump dora to use it.

## Test plan

- [ ] \`go build ./...\` succeeds locally (verified).
- [ ] CI passes.
- [ ] \`docker build .\` succeeds from a clean module cache (will be exercised once PR #694's Dockerfile Go bump merges).