### PR TITLE
feat: track DUE_BPS, reorg cutoff, and Byzantine threshold spec fields

### DIFF
--- a/clients/consensus/chainspec.go
+++ b/clients/consensus/chainspec.go
@@ -78,6 +78,14 @@ type ChainSpecConfig struct {
 	ReorgHeadWeightThreshold        uint64 `yaml:"REORG_HEAD_WEIGHT_THRESHOLD"`
 	ReorgParentWeightThreshold      uint64 `yaml:"REORG_PARENT_WEIGHT_THRESHOLD"`
 	ReorgMaxEpochsSinceFinalization uint64 `yaml:"REORG_MAX_EPOCHS_SINCE_FINALIZATION"`
+	ProposerReorgCutoffBps          uint64 `yaml:"PROPOSER_REORG_CUTOFF_BPS"`
+	ConfirmationByzantineThreshold  uint64 `yaml:"CONFIRMATION_BYZANTINE_THRESHOLD"`
+
+	// Validator timing
+	AggregateDueBps    uint64 `yaml:"AGGREGATE_DUE_BPS"`
+	AttestationDueBps  uint64 `yaml:"ATTESTATION_DUE_BPS"`
+	ContributionDueBps uint64 `yaml:"CONTRIBUTION_DUE_BPS"`
+	SyncMessageDueBps  uint64 `yaml:"SYNC_MESSAGE_DUE_BPS"`
 
 	// Deposit contract
 	DepositChainId         uint64 `yaml:"DEPOSIT_CHAIN_ID"`
@@ -123,6 +131,11 @@ type ChainSpecConfig struct {
 	ChurnLimitQuotientGloas              uint64 `yaml:"CHURN_LIMIT_QUOTIENT_GLOAS"                 check-if-fork:"GloasForkEpoch"`
 	ConsolidationChurnLimitQuotient      uint64 `yaml:"CONSOLIDATION_CHURN_LIMIT_QUOTIENT"         check-if-fork:"GloasForkEpoch"`
 	MaxPerEpochActivationChurnLimitGloas uint64 `yaml:"MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT_GLOAS" check-if-fork:"GloasForkEpoch"`
+	AggregateDueBpsGloas                 uint64 `yaml:"AGGREGATE_DUE_BPS_GLOAS"                    check-if-fork:"GloasForkEpoch"`
+	AttestationDueBpsGloas               uint64 `yaml:"ATTESTATION_DUE_BPS_GLOAS"                  check-if-fork:"GloasForkEpoch"`
+	ContributionDueBpsGloas              uint64 `yaml:"CONTRIBUTION_DUE_BPS_GLOAS"                 check-if-fork:"GloasForkEpoch"`
+	SyncMessageDueBpsGloas               uint64 `yaml:"SYNC_MESSAGE_DUE_BPS_GLOAS"                 check-if-fork:"GloasForkEpoch"`
+	PayloadAttestationDueBps             uint64 `yaml:"PAYLOAD_ATTESTATION_DUE_BPS"                check-if-fork:"GloasForkEpoch"`
 
 	// Heze
 	InclusionListDueBPS uint64 `yaml:"INCLUSION_LIST_DUE_BPS" check-if-fork:"HezeForkEpoch"`


### PR DESCRIPTION
## Summary
- Adds the `*_DUE_BPS` validator timing fields, `PROPOSER_REORG_CUTOFF_BPS`, and `CONFIRMATION_BYZANTINE_THRESHOLD` from `configs/mainnet.yaml` to `ChainSpecConfig`.
- Adds the Gloas variants (`AGGREGATE_DUE_BPS_GLOAS`, `ATTESTATION_DUE_BPS_GLOAS`, `CONTRIBUTION_DUE_BPS_GLOAS`, `SYNC_MESSAGE_DUE_BPS_GLOAS`, `PAYLOAD_ATTESTATION_DUE_BPS`) under the existing Gloas section, fork-gated via `check-if-fork:"GloasForkEpoch"`.
- These now show up in the CL clients page Configuration table instead of "Additional Untracked Fields".

Scope is limited to fields actually present in the consensus-specs yaml config — spec-only constants (TIMELY_*, *_WEIGHT, withdrawal prefixes, request types, derived networking constants like `MAX_REQUEST_BLOB_SIDECARS`) are intentionally left untracked since they live in `specs/**/*.md`, not in any yaml file, and some clients don't report them.

## Test plan
- [ ] Run dora against a Gloas-enabled devnet and verify the new fields appear under "Configuration" on the CL Clients page
- [ ] Verify pre-Gloas networks still render correctly (Gloas variants hidden via `check-if-fork`)
- [ ] Confirm the "Additional Untracked Fields" list no longer includes the BPS / reorg / Byzantine threshold entries