### PR TITLE
fix(gloas): read blob KZG commitments from the bid post-EIP-7732

### DIFF
--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
 	"github.com/ethpandaops/go-eth2-client/spec/capella"
+	"github.com/ethpandaops/go-eth2-client/spec/deneb"
 	"github.com/ethpandaops/go-eth2-client/spec/electra"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/gorilla/mux"
@@ -167,7 +168,15 @@ func SlotBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	commitments := blockData.Block.Message.Body.BlobKZGCommitments
+	body := blockData.Block.Message.Body
+	var commitments []deneb.KZGCommitment
+	if body.Version >= spec.DataVersionGloas {
+		if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
+			commitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
+		}
+	} else {
+		commitments = body.BlobKZGCommitments
+	}
 	if int(blobIndex) >= len(commitments) {
 		http.Error(w, "Blob index out of range", http.StatusBadRequest)
 		return
@@ -450,7 +459,14 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 	proposerSlashings := body.ProposerSlashings
 	blsToExecChanges := body.BLSToExecutionChanges
 	syncAggregate := body.SyncAggregate
-	blobKzgCommitments := body.BlobKZGCommitments
+	var blobKzgCommitments []deneb.KZGCommitment
+	if body.Version >= spec.DataVersionGloas {
+		if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
+			blobKzgCommitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
+		}
+	} else {
+		blobKzgCommitments = body.BlobKZGCommitments
+	}
 	var executionWithdrawals []*capella.Withdrawal
 	if body.ExecutionPayload != nil {
 		executionWithdrawals = body.ExecutionPayload.Withdrawals

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -167,14 +167,7 @@ func SlotBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body := blockData.Block.Message.Body
-	commitments := body.BlobKZGCommitments
-	if body.Version >= spec.DataVersionGloas {
-		commitments = nil
-		if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
-			commitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
-		}
-	}
+	commitments := utils.BlockBodyBlobCommitments(blockData.Block.Message.Body)
 	if int(blobIndex) >= len(commitments) {
 		http.Error(w, "Blob index out of range", http.StatusBadRequest)
 		return
@@ -457,13 +450,7 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 	proposerSlashings := body.ProposerSlashings
 	blsToExecChanges := body.BLSToExecutionChanges
 	syncAggregate := body.SyncAggregate
-	blobKzgCommitments := body.BlobKZGCommitments
-	if body.Version >= spec.DataVersionGloas {
-		blobKzgCommitments = nil
-		if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
-			blobKzgCommitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
-		}
-	}
+	blobKzgCommitments := utils.BlockBodyBlobCommitments(body)
 	var executionWithdrawals []*capella.Withdrawal
 	if body.ExecutionPayload != nil {
 		executionWithdrawals = body.ExecutionPayload.Withdrawals

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
 	"github.com/ethpandaops/go-eth2-client/spec/capella"
-	"github.com/ethpandaops/go-eth2-client/spec/deneb"
 	"github.com/ethpandaops/go-eth2-client/spec/electra"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/gorilla/mux"
@@ -169,13 +168,12 @@ func SlotBlob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body := blockData.Block.Message.Body
-	var commitments []deneb.KZGCommitment
+	commitments := body.BlobKZGCommitments
 	if body.Version >= spec.DataVersionGloas {
+		commitments = nil
 		if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
 			commitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
 		}
-	} else {
-		commitments = body.BlobKZGCommitments
 	}
 	if int(blobIndex) >= len(commitments) {
 		http.Error(w, "Blob index out of range", http.StatusBadRequest)
@@ -459,13 +457,12 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 	proposerSlashings := body.ProposerSlashings
 	blsToExecChanges := body.BLSToExecutionChanges
 	syncAggregate := body.SyncAggregate
-	var blobKzgCommitments []deneb.KZGCommitment
+	blobKzgCommitments := body.BlobKZGCommitments
 	if body.Version >= spec.DataVersionGloas {
+		blobKzgCommitments = nil
 		if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
 			blobKzgCommitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
 		}
-	} else {
-		blobKzgCommitments = body.BlobKZGCommitments
 	}
 	var executionWithdrawals []*capella.Withdrawal
 	if body.ExecutionPayload != nil {

--- a/handlers/transaction.go
+++ b/handlers/transaction.go
@@ -1360,9 +1360,6 @@ func loadBlobData(pageData *models.TransactionPageData, ethTx *ethtypes.Transact
 	var kzgCommitments [][]byte
 	if blockData != nil && blockData.Block != nil && blockData.Block.Message != nil && blockData.Block.Message.Body != nil {
 		commitments := utils.BlockBodyBlobCommitments(blockData.Block.Message.Body)
-		if len(commitments) == 0 && len(blobHashes) > 0 {
-			logrus.Warnf("blob tx in block at slot %v has no resolvable KZG commitments", blockData.Block.Message.Slot)
-		}
 		// Find the commitments that correspond to this transaction's blobs
 		// by matching versioned hashes
 		kzgCommitments = utils.MatchBlobCommitments(blobHashes, commitments)

--- a/handlers/transaction.go
+++ b/handlers/transaction.go
@@ -16,7 +16,6 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethpandaops/go-eth2-client/spec"
 	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
-	"github.com/ethpandaops/go-eth2-client/spec/deneb"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/golang/snappy"
 	"github.com/gorilla/mux"
@@ -1362,15 +1361,14 @@ func loadBlobData(pageData *models.TransactionPageData, ethTx *ethtypes.Transact
 	var kzgCommitments [][]byte
 	if blockData != nil && blockData.Block != nil && blockData.Block.Message != nil && blockData.Block.Message.Body != nil {
 		body := blockData.Block.Message.Body
-		var commitments []deneb.KZGCommitment
+		commitments := body.BlobKZGCommitments
 		if body.Version >= spec.DataVersionGloas {
+			commitments = nil
 			if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
 				commitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
 			} else {
 				logrus.Warnf("blob tx in block at slot %v has no SignedExecutionPayloadBid; commitments unavailable", blockData.Block.Message.Slot)
 			}
-		} else {
-			commitments = body.BlobKZGCommitments
 		}
 		// Find the commitments that correspond to this transaction's blobs
 		// by matching versioned hashes

--- a/handlers/transaction.go
+++ b/handlers/transaction.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethpandaops/go-eth2-client/spec"
 	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/golang/snappy"
@@ -1360,15 +1359,9 @@ func loadBlobData(pageData *models.TransactionPageData, ethTx *ethtypes.Transact
 	// Get KZG commitments from beacon block
 	var kzgCommitments [][]byte
 	if blockData != nil && blockData.Block != nil && blockData.Block.Message != nil && blockData.Block.Message.Body != nil {
-		body := blockData.Block.Message.Body
-		commitments := body.BlobKZGCommitments
-		if body.Version >= spec.DataVersionGloas {
-			commitments = nil
-			if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
-				commitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
-			} else {
-				logrus.Warnf("blob tx in block at slot %v has no SignedExecutionPayloadBid; commitments unavailable", blockData.Block.Message.Slot)
-			}
+		commitments := utils.BlockBodyBlobCommitments(blockData.Block.Message.Body)
+		if len(commitments) == 0 && len(blobHashes) > 0 {
+			logrus.Warnf("blob tx in block at slot %v has no resolvable KZG commitments", blockData.Block.Message.Slot)
 		}
 		// Find the commitments that correspond to this transaction's blobs
 		// by matching versioned hashes

--- a/handlers/transaction.go
+++ b/handlers/transaction.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethpandaops/go-eth2-client/spec"
 	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
+	"github.com/ethpandaops/go-eth2-client/spec/deneb"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/golang/snappy"
 	"github.com/gorilla/mux"
@@ -1359,7 +1361,15 @@ func loadBlobData(pageData *models.TransactionPageData, ethTx *ethtypes.Transact
 	// Get KZG commitments from beacon block
 	var kzgCommitments [][]byte
 	if blockData != nil && blockData.Block != nil && blockData.Block.Message != nil && blockData.Block.Message.Body != nil {
-		commitments := blockData.Block.Message.Body.BlobKZGCommitments
+		body := blockData.Block.Message.Body
+		var commitments []deneb.KZGCommitment
+		if body.Version >= spec.DataVersionGloas {
+			if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
+				commitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
+			}
+		} else {
+			commitments = body.BlobKZGCommitments
+		}
 		// Find the commitments that correspond to this transaction's blobs
 		// by matching versioned hashes
 		kzgCommitments = utils.MatchBlobCommitments(blobHashes, commitments)

--- a/handlers/transaction.go
+++ b/handlers/transaction.go
@@ -1366,6 +1366,8 @@ func loadBlobData(pageData *models.TransactionPageData, ethTx *ethtypes.Transact
 		if body.Version >= spec.DataVersionGloas {
 			if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
 				commitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
+			} else {
+				logrus.Warnf("blob tx in block at slot %v has no SignedExecutionPayloadBid; commitments unavailable", blockData.Block.Message.Slot)
 			}
 		} else {
 			commitments = body.BlobKZGCommitments

--- a/indexer/beacon/block.go
+++ b/indexer/beacon/block.go
@@ -13,9 +13,9 @@ import (
 	"github.com/ethpandaops/dora/db"
 	"github.com/ethpandaops/dora/dbtypes"
 	"github.com/ethpandaops/dora/utils"
+	"github.com/ethpandaops/go-eth2-client/spec"
 	"github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
-	"github.com/ethpandaops/go-eth2-client/spec/version"
 	"github.com/jmoiron/sqlx"
 	dynssz "github.com/pk910/dynamic-ssz"
 )
@@ -431,7 +431,7 @@ func (block *Block) setBlockIndex(body *all.SignedBeaconBlock, payload *all.Sign
 
 	bbody := body.Message.Body
 	blockIndex.Graffiti = bbody.Graffiti
-	if bbody.Version >= version.DataVersionGloas {
+	if bbody.Version >= spec.DataVersionGloas {
 		if bbody.SignedExecutionPayloadBid != nil && bbody.SignedExecutionPayloadBid.Message != nil {
 			blockIndex.BlobCount = uint64(len(bbody.SignedExecutionPayloadBid.Message.BlobKZGCommitments))
 		}

--- a/indexer/beacon/block.go
+++ b/indexer/beacon/block.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethpandaops/dora/db"
 	"github.com/ethpandaops/dora/dbtypes"
 	"github.com/ethpandaops/dora/utils"
-	"github.com/ethpandaops/go-eth2-client/spec"
 	"github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/jmoiron/sqlx"
@@ -431,13 +430,7 @@ func (block *Block) setBlockIndex(body *all.SignedBeaconBlock, payload *all.Sign
 
 	bbody := body.Message.Body
 	blockIndex.Graffiti = bbody.Graffiti
-	if bbody.Version >= spec.DataVersionGloas {
-		if bbody.SignedExecutionPayloadBid != nil && bbody.SignedExecutionPayloadBid.Message != nil {
-			blockIndex.BlobCount = uint64(len(bbody.SignedExecutionPayloadBid.Message.BlobKZGCommitments))
-		}
-	} else {
-		blockIndex.BlobCount = uint64(len(bbody.BlobKZGCommitments))
-	}
+	blockIndex.BlobCount = uint64(len(utils.BlockBodyBlobCommitments(bbody)))
 
 	if extra, err := getBlockExecutionExtraData(body); err == nil {
 		blockIndex.ExecutionExtraData = extra

--- a/indexer/beacon/block.go
+++ b/indexer/beacon/block.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethpandaops/dora/utils"
 	"github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/ethpandaops/go-eth2-client/spec/version"
 	"github.com/jmoiron/sqlx"
 	dynssz "github.com/pk910/dynamic-ssz"
 )
@@ -430,7 +431,13 @@ func (block *Block) setBlockIndex(body *all.SignedBeaconBlock, payload *all.Sign
 
 	bbody := body.Message.Body
 	blockIndex.Graffiti = bbody.Graffiti
-	blockIndex.BlobCount = uint64(len(bbody.BlobKZGCommitments))
+	if bbody.Version >= version.DataVersionGloas {
+		if bbody.SignedExecutionPayloadBid != nil && bbody.SignedExecutionPayloadBid.Message != nil {
+			blockIndex.BlobCount = uint64(len(bbody.SignedExecutionPayloadBid.Message.BlobKZGCommitments))
+		}
+	} else {
+		blockIndex.BlobCount = uint64(len(bbody.BlobKZGCommitments))
+	}
 
 	if extra, err := getBlockExecutionExtraData(body); err == nil {
 		blockIndex.ExecutionExtraData = extra

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -12,8 +12,10 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
 	"github.com/ethpandaops/go-eth2-client/spec/capella"
+	"github.com/ethpandaops/go-eth2-client/spec/deneb"
 	"github.com/ethpandaops/go-eth2-client/spec/electra"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/ethpandaops/go-eth2-client/spec/version"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -295,7 +297,14 @@ func (dbw *dbWriter) buildDbBlock(block *Block, epochStats *EpochStats, override
 	proposerSlashings := body.ProposerSlashings
 	blsToExecChanges := body.BLSToExecutionChanges
 	syncAggregate := body.SyncAggregate
-	blobKzgCommitments := body.BlobKZGCommitments
+	var blobKzgCommitments []deneb.KZGCommitment
+	if body.Version >= version.DataVersionGloas {
+		if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
+			blobKzgCommitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
+		}
+	} else {
+		blobKzgCommitments = body.BlobKZGCommitments
+	}
 	var executionBlockHash phase0.Hash32
 
 	var executionBlockNumber uint64
@@ -544,7 +553,14 @@ func (dbw *dbWriter) buildDbEpoch(epoch phase0.Epoch, blocks []*Block, epochStat
 			proposerSlashings := body.ProposerSlashings
 			blsToExecChanges := body.BLSToExecutionChanges
 			syncAggregate := body.SyncAggregate
-			blobKzgCommitments := body.BlobKZGCommitments
+			var blobKzgCommitments []deneb.KZGCommitment
+			if body.Version >= version.DataVersionGloas {
+				if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
+					blobKzgCommitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
+				}
+			} else {
+				blobKzgCommitments = body.BlobKZGCommitments
+			}
 
 			var executionTransactions []bellatrix.Transaction
 			var executionWithdrawals []*capella.Withdrawal

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
 	"github.com/ethpandaops/go-eth2-client/spec/capella"
-	"github.com/ethpandaops/go-eth2-client/spec/deneb"
 	"github.com/ethpandaops/go-eth2-client/spec/electra"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/jmoiron/sqlx"
@@ -296,13 +295,12 @@ func (dbw *dbWriter) buildDbBlock(block *Block, epochStats *EpochStats, override
 	proposerSlashings := body.ProposerSlashings
 	blsToExecChanges := body.BLSToExecutionChanges
 	syncAggregate := body.SyncAggregate
-	var blobKzgCommitments []deneb.KZGCommitment
+	blobKzgCommitments := body.BlobKZGCommitments
 	if body.Version >= spec.DataVersionGloas {
+		blobKzgCommitments = nil
 		if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
 			blobKzgCommitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
 		}
-	} else {
-		blobKzgCommitments = body.BlobKZGCommitments
 	}
 	var executionBlockHash phase0.Hash32
 
@@ -552,13 +550,12 @@ func (dbw *dbWriter) buildDbEpoch(epoch phase0.Epoch, blocks []*Block, epochStat
 			proposerSlashings := body.ProposerSlashings
 			blsToExecChanges := body.BLSToExecutionChanges
 			syncAggregate := body.SyncAggregate
-			var blobKzgCommitments []deneb.KZGCommitment
+			blobKzgCommitments := body.BlobKZGCommitments
 			if body.Version >= spec.DataVersionGloas {
+				blobKzgCommitments = nil
 				if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
 					blobKzgCommitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
 				}
-			} else {
-				blobKzgCommitments = body.BlobKZGCommitments
 			}
 
 			var executionTransactions []bellatrix.Transaction

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec/deneb"
 	"github.com/ethpandaops/go-eth2-client/spec/electra"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
-	"github.com/ethpandaops/go-eth2-client/spec/version"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -298,7 +297,7 @@ func (dbw *dbWriter) buildDbBlock(block *Block, epochStats *EpochStats, override
 	blsToExecChanges := body.BLSToExecutionChanges
 	syncAggregate := body.SyncAggregate
 	var blobKzgCommitments []deneb.KZGCommitment
-	if body.Version >= version.DataVersionGloas {
+	if body.Version >= spec.DataVersionGloas {
 		if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
 			blobKzgCommitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
 		}
@@ -554,7 +553,7 @@ func (dbw *dbWriter) buildDbEpoch(epoch phase0.Epoch, blocks []*Block, epochStat
 			blsToExecChanges := body.BLSToExecutionChanges
 			syncAggregate := body.SyncAggregate
 			var blobKzgCommitments []deneb.KZGCommitment
-			if body.Version >= version.DataVersionGloas {
+			if body.Version >= spec.DataVersionGloas {
 				if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
 					blobKzgCommitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
 				}

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -295,13 +295,7 @@ func (dbw *dbWriter) buildDbBlock(block *Block, epochStats *EpochStats, override
 	proposerSlashings := body.ProposerSlashings
 	blsToExecChanges := body.BLSToExecutionChanges
 	syncAggregate := body.SyncAggregate
-	blobKzgCommitments := body.BlobKZGCommitments
-	if body.Version >= spec.DataVersionGloas {
-		blobKzgCommitments = nil
-		if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
-			blobKzgCommitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
-		}
-	}
+	blobKzgCommitments := utils.BlockBodyBlobCommitments(body)
 	var executionBlockHash phase0.Hash32
 
 	var executionBlockNumber uint64
@@ -550,13 +544,7 @@ func (dbw *dbWriter) buildDbEpoch(epoch phase0.Epoch, blocks []*Block, epochStat
 			proposerSlashings := body.ProposerSlashings
 			blsToExecChanges := body.BLSToExecutionChanges
 			syncAggregate := body.SyncAggregate
-			blobKzgCommitments := body.BlobKZGCommitments
-			if body.Version >= spec.DataVersionGloas {
-				blobKzgCommitments = nil
-				if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
-					blobKzgCommitments = body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
-				}
-			}
+			blobKzgCommitments := utils.BlockBodyBlobCommitments(body)
 
 			var executionTransactions []bellatrix.Transaction
 			var executionWithdrawals []*capella.Withdrawal

--- a/utils/blobs.go
+++ b/utils/blobs.go
@@ -4,8 +4,28 @@ import (
 	"crypto/sha256"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethpandaops/go-eth2-client/spec"
+	"github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/deneb"
 )
+
+// BlockBodyBlobCommitments returns the blob KZG commitments declared by a
+// beacon block body, transparently sourcing them from the body itself
+// pre-Gloas and from the embedded execution payload bid post-EIP-7732
+// (where they were moved off the body). Returns nil on a Gloas+ body
+// that's missing the bid container.
+func BlockBodyBlobCommitments(body *all.BeaconBlockBody) []deneb.KZGCommitment {
+	if body == nil {
+		return nil
+	}
+	if body.Version >= spec.DataVersionGloas {
+		if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
+			return body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
+		}
+		return nil
+	}
+	return body.BlobKZGCommitments
+}
 
 // MatchBlobCommitments finds the KZG commitments from the block that match
 // the given versioned hashes from a transaction.

--- a/utils/blobs.go
+++ b/utils/blobs.go
@@ -10,19 +10,11 @@ import (
 )
 
 // BlockBodyBlobCommitments returns the blob KZG commitments declared by a
-// beacon block body, transparently sourcing them from the body itself
-// pre-Gloas and from the embedded execution payload bid post-EIP-7732
-// (where they were moved off the body). Returns nil on a Gloas+ body
-// that's missing the bid container.
+// beacon block body — sourced from the body pre-Gloas, and from the
+// embedded execution payload bid post-EIP-7732 (where they were moved).
 func BlockBodyBlobCommitments(body *all.BeaconBlockBody) []deneb.KZGCommitment {
-	if body == nil {
-		return nil
-	}
 	if body.Version >= spec.DataVersionGloas {
-		if body.SignedExecutionPayloadBid != nil && body.SignedExecutionPayloadBid.Message != nil {
-			return body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
-		}
-		return nil
+		return body.SignedExecutionPayloadBid.Message.BlobKZGCommitments
 	}
 	return body.BlobKZGCommitments
 }


### PR DESCRIPTION
## Summary
EIP-7732 (Gloas) moved `blob_kzg_commitments` off the `BeaconBlockBody` onto the execution payload bid (`signed_execution_payload_bid.message.blob_kzg_commitments`). Every read site in dora still pulled from the body, so post-Gloas blocks showed empty blob data everywhere.

## Symptoms (observed on a Gloas devnet)
- Slot list / epoch totals: `BlobCount=0` on every blob-bearing block
- Slot detail page: no **Blobs** tab (`BlobsCount=0` hides it)
- `/slot/<root>/blob/<index>`: returned `Blob index out of range`
- Transaction pages: versioned-hash → KZG-commitment matching produced empty commitments

## Fix
Single helper `utils.BlockBodyBlobCommitments(body)` returns the right commitment list regardless of fork — body field pre-Gloas, bid field post-Gloas. All six call sites now use it.

Sites touched:
- `indexer/beacon/block.go` — `BlockBodyIndex.BlobCount`
- `indexer/beacon/writedb.go` (×2) — `buildDbBlock` + `buildDbEpoch`
- `handlers/slot.go` (×2) — single-blob download + slot detail tab data
- `handlers/transaction.go` — tx page blob-commitment match (with warn log when commitments unavailable on a blob-bearing block)
- `utils/blobs.go` — new helper

## Test plan
- [ ] Restart dora against a Gloas devnet with blob-producing spamoor
- [ ] Slot list shows non-zero `Txs / Blobs` (e.g. `54 / 15`)
- [ ] Slot detail page shows a **Blobs N** tab and lists the commitments
- [ ] `/slot/<root>/blob/0` returns blob payload
- [ ] Transaction detail page shows commitments next to each versioned hash