### PR TITLE
ci: drop macos/amd64 release builds

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -200,47 +200,6 @@ jobs:
         path: ./bin/*
         name: explorer_windows_amd64
 
-  build_darwin_amd64_binary:
-    name: Build macos/amd64 binary
-    needs: [build_ui_package]
-    runs-on: macos-15-intel
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
-
-    # setup global dependencies
-    - name: Set up go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version: 1.25.x
-
-    # setup project dependencies
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-
-    # download UI build artifacts
-    - name: Download UI build artifacts
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: ui-package
-        path: ./ui-package/dist
-
-    # build binaries
-    - name: Build macos amd64 binary
-      run: |
-        make build
-      env:
-        RELEASE: ${{ inputs.release }}
-
-    # upload artifacts
-    - name: "Upload artifact: explorer_darwin_amd64"
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        path: ./bin/*
-        name: explorer_darwin_amd64
-
   build_darwin_arm64_binary:
     name: Build macos/arm64 binary
     needs: [build_ui_package]

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -117,10 +117,6 @@ jobs:
       run: |
         cd explorer_linux_arm64
         tar -czf ../dora_snapshot_linux_arm64.tar.gz .
-    - name: "Generate release package: dora_snapshot_darwin_amd64.tar.gz"
-      run: |
-        cd explorer_darwin_amd64
-        tar -czf ../dora_snapshot_darwin_amd64.tar.gz .
     - name: "Generate release package: dora_snapshot_darwin_arm64.tar.gz"
       run: |
         cd explorer_darwin_arm64
@@ -145,11 +141,9 @@ jobs:
           | [dora_snapshot_windows_amd64.zip](https://github.com/ethpandaops/dora/releases/download/snapshot/dora_snapshot_windows_amd64.zip) | dora executables for windows/amd64 |
           | [dora_snapshot_linux_amd64.tar.gz](https://github.com/ethpandaops/dora/releases/download/snapshot/dora_snapshot_linux_amd64.tar.gz) | dora executables for linux/amd64 |
           | [dora_snapshot_linux_arm64.tar.gz](https://github.com/ethpandaops/dora/releases/download/snapshot/dora_snapshot_linux_arm64.tar.gz) | dora executables for linux/arm64 |
-          | [dora_snapshot_darwin_amd64.tar.gz](https://github.com/ethpandaops/dora/releases/download/snapshot/dora_snapshot_darwin_amd64.tar.gz) | dora executable for macos/amd64 |
           | [dora_snapshot_darwin_arm64.tar.gz](https://github.com/ethpandaops/dora/releases/download/snapshot/dora_snapshot_darwin_arm64.tar.gz) | dora executable for macos/arm64 |
         files: |
           dora_snapshot_windows_amd64.zip
           dora_snapshot_linux_amd64.tar.gz
           dora_snapshot_linux_arm64.tar.gz
-          dora_snapshot_darwin_amd64.tar.gz
           dora_snapshot_darwin_arm64.tar.gz

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -90,10 +90,6 @@ jobs:
       run: |
         cd explorer_linux_arm64
         tar -czf ../dora_${{ inputs.version }}_linux_arm64.tar.gz .
-    - name: "Generate release package: dora_${{ inputs.version }}_darwin_amd64.tar.gz"
-      run: |
-        cd explorer_darwin_amd64
-        tar -czf ../dora_${{ inputs.version }}_darwin_amd64.tar.gz .
     - name: "Generate release package: dora_${{ inputs.version }}_darwin_arm64.tar.gz"
       run: |
         cd explorer_darwin_arm64
@@ -124,11 +120,9 @@ jobs:
           | [dora_${{ inputs.version }}_windows_amd64.zip](https://github.com/ethpandaops/dora/releases/download/v${{ inputs.version }}/dora_${{ inputs.version }}_windows_amd64.zip) | dora executables for windows/amd64 |
           | [dora_${{ inputs.version }}_linux_amd64.tar.gz](https://github.com/ethpandaops/dora/releases/download/v${{ inputs.version }}/dora_${{ inputs.version }}_linux_amd64.tar.gz) | dora executables for linux/amd64 |
           | [dora_${{ inputs.version }}_linux_arm64.tar.gz](https://github.com/ethpandaops/dora/releases/download/v${{ inputs.version }}/dora_${{ inputs.version }}_linux_arm64.tar.gz) | dora executables for linux/arm64 |
-          | [dora_${{ inputs.version }}_darwin_amd64.tar.gz](https://github.com/ethpandaops/dora/releases/download/v${{ inputs.version }}/dora_${{ inputs.version }}_darwin_amd64.tar.gz) | dora executable for macos/amd64 |
           | [dora_${{ inputs.version }}_darwin_arm64.tar.gz](https://github.com/ethpandaops/dora/releases/download/v${{ inputs.version }}/dora_${{ inputs.version }}_darwin_arm64.tar.gz) | dora executable for macos/arm64 |
         files: |
           dora_${{ inputs.version }}_windows_amd64.zip
           dora_${{ inputs.version }}_linux_amd64.tar.gz
           dora_${{ inputs.version }}_linux_arm64.tar.gz
-          dora_${{ inputs.version }}_darwin_amd64.tar.gz
           dora_${{ inputs.version }}_darwin_arm64.tar.gz


### PR DESCRIPTION
## Summary
- Remove the `build_darwin_amd64_binary` job (ran on `macos-15-intel`) from the shared build workflow
- Drop the darwin_amd64 tarball steps, release-notes table row, and files entry from the snapshot and release workflows
- Mac builds are now arm64-only

## Test plan
- [ ] Trigger Build master and confirm the snapshot release contains windows_amd64, linux_amd64, linux_arm64, darwin_arm64 only
- [ ] On the next tagged release, confirm the release artifacts and release-notes table match