### PR TITLE
Aggregated Internal Transaction Index

### DIFF
--- a/db/el_transactions_internal.go
+++ b/db/el_transactions_internal.go
@@ -9,7 +9,8 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// InsertElTransactionsInternal inserts internal transaction index entries in batch.
+// InsertElTransactionsInternal inserts per-account internal-tx aggregates in
+// batch. Each entry is one (tx_uid, account_id) row.
 func InsertElTransactionsInternal(ctx context.Context, dbTx *sqlx.Tx, entries []*dbtypes.ElTransactionInternal) error {
 	if len(entries) == 0 {
 		return nil
@@ -21,12 +22,12 @@ func InsertElTransactionsInternal(ctx context.Context, dbTx *sqlx.Tx, entries []
 			dbtypes.DBEnginePgsql:  "INSERT INTO el_transactions_internal ",
 			dbtypes.DBEngineSqlite: "INSERT OR REPLACE INTO el_transactions_internal ",
 		}),
-		"(tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw)",
+		"(tx_uid, account_id, in_count, out_count, call_type_mask, value_in, value_out, gas_used)",
 		" VALUES ",
 	)
 
 	argIdx := 0
-	fieldCount := 7
+	fieldCount := 8
 	args := make([]any, len(entries)*fieldCount)
 
 	for i, entry := range entries {
@@ -43,22 +44,24 @@ func InsertElTransactionsInternal(ctx context.Context, dbTx *sqlx.Tx, entries []
 		fmt.Fprint(&sql, ")")
 
 		args[argIdx+0] = entry.TxUid
-		args[argIdx+1] = entry.TxCallIdx
-		args[argIdx+2] = entry.CallType
-		args[argIdx+3] = entry.FromID
-		args[argIdx+4] = entry.ToID
-		args[argIdx+5] = entry.Value
-		args[argIdx+6] = entry.ValueRaw
+		args[argIdx+1] = entry.AccountID
+		args[argIdx+2] = entry.InCount
+		args[argIdx+3] = entry.OutCount
+		args[argIdx+4] = entry.CallTypeMask
+		args[argIdx+5] = entry.ValueIn
+		args[argIdx+6] = entry.ValueOut
+		args[argIdx+7] = entry.GasUsed
 		argIdx += fieldCount
 	}
 
 	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
-		dbtypes.DBEnginePgsql: " ON CONFLICT (tx_uid, tx_callidx) DO UPDATE SET" +
-			" call_type = excluded.call_type," +
-			" from_id = excluded.from_id," +
-			" to_id = excluded.to_id," +
-			" value = excluded.value," +
-			" value_raw = excluded.value_raw",
+		dbtypes.DBEnginePgsql: " ON CONFLICT (tx_uid, account_id) DO UPDATE SET" +
+			" in_count = excluded.in_count," +
+			" out_count = excluded.out_count," +
+			" call_type_mask = excluded.call_type_mask," +
+			" value_in = excluded.value_in," +
+			" value_out = excluded.value_out," +
+			" gas_used = excluded.gas_used",
 		dbtypes.DBEngineSqlite: "",
 	}))
 
@@ -67,11 +70,11 @@ func InsertElTransactionsInternal(ctx context.Context, dbTx *sqlx.Tx, entries []
 }
 
 // HasElTransactionsInternalByAccount returns true if the given account has any
-// internal transactions (as sender or receiver). Uses EXISTS for O(1) lookup.
+// internal-tx aggregate rows. EXISTS scan on the (account_id, tx_uid DESC) idx.
 func HasElTransactionsInternalByAccount(ctx context.Context, accountID uint64) (bool, error) {
 	var exists bool
 	err := ReaderDb.GetContext(ctx, &exists,
-		"SELECT EXISTS(SELECT 1 FROM el_transactions_internal WHERE from_id = $1 LIMIT 1) OR EXISTS(SELECT 1 FROM el_transactions_internal WHERE to_id = $1 LIMIT 1)",
+		"SELECT EXISTS(SELECT 1 FROM el_transactions_internal WHERE account_id = $1 LIMIT 1)",
 		accountID,
 	)
 	if err != nil {
@@ -84,38 +87,24 @@ func HasElTransactionsInternalByAccount(ctx context.Context, accountID uint64) (
 // If the actual count exceeds this, the query returns this limit and sets the "more" flag.
 const MaxAccountInternalTxCount = 100000
 
-// GetElTransactionsInternalByAccount returns internal transactions
-// involving the given account (as sender or receiver), ordered by tx_uid DESC.
-// Uses UNION ALL instead of OR to enable index scans on the composite indexes
-// (from_id, tx_uid DESC) and (to_id, tx_uid DESC).
-// NULLS LAST is required to match the index definition and enable index scans.
+// GetElTransactionsInternalByAccount returns per-tx aggregate rows involving
+// the given account, ordered by tx_uid DESC. The (account_id, tx_uid DESC)
+// index makes this a direct index scan.
 func GetElTransactionsInternalByAccount(
 	ctx context.Context,
 	accountID uint64,
 	offset uint64,
 	limit uint32,
 ) ([]*dbtypes.ElTransactionInternal, uint64, error) {
-	// Data query: UNION ALL with pushed LIMIT into each branch
 	var sql strings.Builder
-	innerLimit := offset + uint64(limit)
-	args := []any{accountID, accountID, accountID, innerLimit}
+	args := []any{accountID, limit}
 
 	fmt.Fprint(&sql, `
-		SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw
-		FROM (
-			SELECT * FROM (SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw
-			FROM el_transactions_internal WHERE from_id = $1
-			ORDER BY tx_uid DESC NULLS LAST
-			LIMIT $4) AS a
-			UNION ALL
-			SELECT * FROM (SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw
-			FROM el_transactions_internal WHERE to_id = $2 AND from_id != $3
-			ORDER BY tx_uid DESC NULLS LAST
-			LIMIT $4) AS b
-		) combined
-		ORDER BY tx_uid DESC, tx_callidx ASC
-		LIMIT $5`)
-	args = append(args, limit)
+		SELECT tx_uid, account_id, in_count, out_count, call_type_mask, value_in, value_out, gas_used
+		FROM el_transactions_internal
+		WHERE account_id = $1
+		ORDER BY tx_uid DESC
+		LIMIT $2`)
 
 	if offset > 0 {
 		args = append(args, offset)
@@ -128,11 +117,11 @@ func GetElTransactionsInternalByAccount(
 		return nil, 0, err
 	}
 
-	// Count query: separate index-only scans per direction, capped at MaxAccountInternalTxCount.
+	// Count query: capped at MaxAccountInternalTxCount.
 	countSQL := `
-		SELECT
-			(SELECT COUNT(*) FROM (SELECT 1 FROM el_transactions_internal WHERE from_id = $1 LIMIT $2) a) +
-			(SELECT COUNT(*) FROM (SELECT 1 FROM el_transactions_internal WHERE to_id = $1 LIMIT $2) b)`
+		SELECT COUNT(*) FROM (
+			SELECT 1 FROM el_transactions_internal WHERE account_id = $1 LIMIT $2
+		) a`
 	var totalCount uint64
 	err = ReaderDb.GetContext(ctx, &totalCount, countSQL, accountID, MaxAccountInternalTxCount)
 	if err != nil {
@@ -146,8 +135,8 @@ func GetElTransactionsInternalByAccount(
 	return entries, totalCount, nil
 }
 
-// GetElTransactionsInternalCountByTxUid returns the number of internal
-// transactions for a given transaction UID.
+// GetElTransactionsInternalCountByTxUid returns the number of distinct
+// accounts touched by the transaction's internal calls.
 func GetElTransactionsInternalCountByTxUid(ctx context.Context, txUid uint64) (uint64, error) {
 	var count uint64
 	err := ReaderDb.GetContext(ctx, &count,
@@ -160,13 +149,14 @@ func GetElTransactionsInternalCountByTxUid(ctx context.Context, txUid uint64) (u
 	return count, nil
 }
 
-// GetElTransactionsInternalByTxUid returns all internal transactions
-// for a given transaction UID.
+// GetElTransactionsInternalByTxUid returns the per-account aggregate rows
+// for a transaction. There is no natural ordering between accounts, so we
+// sort by account_id for stability.
 func GetElTransactionsInternalByTxUid(ctx context.Context, txUid uint64) ([]*dbtypes.ElTransactionInternal, error) {
 	entries := []*dbtypes.ElTransactionInternal{}
 	err := ReaderDb.SelectContext(ctx, &entries,
-		"SELECT tx_uid, tx_callidx, call_type, from_id, to_id, value, value_raw"+
-			" FROM el_transactions_internal WHERE tx_uid = $1 ORDER BY tx_callidx ASC",
+		"SELECT tx_uid, account_id, in_count, out_count, call_type_mask, value_in, value_out, gas_used"+
+			" FROM el_transactions_internal WHERE tx_uid = $1 ORDER BY account_id ASC",
 		txUid,
 	)
 	if err != nil {

--- a/db/schema/pgsql/20260519000000_internal-tx-aggregate.sql
+++ b/db/schema/pgsql/20260519000000_internal-tx-aggregate.sql
@@ -1,0 +1,79 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Aggregate el_transactions_internal: collapse the per-call index (one row per
+-- sub-call frame) into a per-account aggregate (one row per touched account
+-- per transaction). Internal-call-heavy txs (eg. 100 calls to the same
+-- contract) drop from 100 rows to ~2 rows, reducing per-slot insert pressure.
+--
+-- Historical migration preserves in/out call counts, value_in/out and
+-- call_type_mask (rebuilt from the old per-row call_type via
+-- SUM(DISTINCT 1<<call_type) — since each bit is a distinct power of two,
+-- summing distinct values equals bitwise OR). gas_used is zeroed because the
+-- old schema didn't track it; it only repopulates when affected blocks are
+-- re-indexed.
+
+DROP INDEX IF EXISTS "el_internal_tx_from_idx";
+DROP INDEX IF EXISTS "el_internal_tx_to_idx";
+DROP INDEX IF EXISTS "el_internal_tx_from_only_idx";
+DROP INDEX IF EXISTS "el_internal_tx_to_only_idx";
+DROP INDEX IF EXISTS "el_internal_tx_hash_idx";
+
+CREATE TABLE public."el_transactions_internal_new" (
+    tx_uid BIGINT NOT NULL,
+    account_id BIGINT NOT NULL,
+    in_count SMALLINT NOT NULL DEFAULT 0,
+    out_count SMALLINT NOT NULL DEFAULT 0,
+    call_type_mask SMALLINT NOT NULL DEFAULT 0,
+    value_in DOUBLE PRECISION NOT NULL DEFAULT 0,
+    value_out DOUBLE PRECISION NOT NULL DEFAULT 0,
+    gas_used BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (tx_uid, account_id)
+);
+
+INSERT INTO public."el_transactions_internal_new"
+    (tx_uid, account_id, in_count, out_count, call_type_mask, value_in, value_out, gas_used)
+SELECT tx_uid, account_id,
+       LEAST(SUM(in_count), 32767)::SMALLINT AS in_count,
+       LEAST(SUM(out_count), 32767)::SMALLINT AS out_count,
+       SUM(call_type_mask)::SMALLINT AS call_type_mask,
+       SUM(value_in) AS value_in,
+       SUM(value_out) AS value_out,
+       0::BIGINT AS gas_used
+FROM (
+    -- from-side: every internal call contributes to the caller's out_count.
+    -- call_type_mask stays 0 here since the mask only tracks incoming types.
+    SELECT tx_uid, from_id AS account_id,
+           0 AS in_count,
+           COUNT(*) AS out_count,
+           0 AS call_type_mask,
+           0::DOUBLE PRECISION AS value_in,
+           SUM(value) AS value_out
+    FROM public."el_transactions_internal"
+    GROUP BY tx_uid, from_id
+    UNION ALL
+    -- to-side: every internal call contributes to the callee's in_count.
+    -- SUM(DISTINCT 1<<call_type) reconstructs the bitmask of incoming types.
+    SELECT tx_uid, to_id AS account_id,
+           COUNT(*) AS in_count,
+           0 AS out_count,
+           SUM(DISTINCT (1 << call_type::INTEGER)) AS call_type_mask,
+           SUM(value) AS value_in,
+           0::DOUBLE PRECISION AS value_out
+    FROM public."el_transactions_internal"
+    GROUP BY tx_uid, to_id
+) sides
+GROUP BY tx_uid, account_id;
+
+DROP TABLE public."el_transactions_internal";
+ALTER TABLE public."el_transactions_internal_new" RENAME TO "el_transactions_internal";
+
+CREATE INDEX IF NOT EXISTS "el_internal_tx_account_idx"
+    ON public."el_transactions_internal"
+    ("account_id" ASC NULLS FIRST, "tx_uid" DESC NULLS LAST);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/db/schema/sqlite/20260519000000_internal-tx-aggregate.sql
+++ b/db/schema/sqlite/20260519000000_internal-tx-aggregate.sql
@@ -1,0 +1,80 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Aggregate el_transactions_internal: collapse the per-call index (one row per
+-- sub-call frame) into a per-account aggregate (one row per touched account
+-- per transaction). Internal-call-heavy txs (eg. 100 calls to the same
+-- contract) drop from 100 rows to ~2 rows, reducing per-slot insert pressure.
+--
+-- Historical migration preserves in/out call counts, value_in/out and
+-- call_type_mask (rebuilt from the old per-row call_type via
+-- SUM(DISTINCT 1<<call_type) — since each bit is a distinct power of two,
+-- summing distinct values equals bitwise OR). gas_used is zeroed because the
+-- old schema didn't track it; it only repopulates when affected blocks are
+-- re-indexed.
+
+DROP INDEX IF EXISTS "el_internal_tx_from_idx";
+DROP INDEX IF EXISTS "el_internal_tx_to_idx";
+DROP INDEX IF EXISTS "el_internal_tx_from_only_idx";
+DROP INDEX IF EXISTS "el_internal_tx_to_only_idx";
+DROP INDEX IF EXISTS "el_internal_tx_hash_idx";
+
+CREATE TABLE "el_transactions_internal_new" (
+    tx_uid INTEGER NOT NULL,
+    account_id INTEGER NOT NULL,
+    in_count INTEGER NOT NULL DEFAULT 0,
+    out_count INTEGER NOT NULL DEFAULT 0,
+    call_type_mask INTEGER NOT NULL DEFAULT 0,
+    value_in REAL NOT NULL DEFAULT 0,
+    value_out REAL NOT NULL DEFAULT 0,
+    gas_used INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT el_transactions_internal_pkey PRIMARY KEY (tx_uid, account_id)
+);
+
+-- SQLite stores INTEGERs flexibly so the SMALLINT type hint isn't enforced;
+-- no clamp needed here. The indexer clamps counts on insert.
+INSERT INTO "el_transactions_internal_new"
+    (tx_uid, account_id, in_count, out_count, call_type_mask, value_in, value_out, gas_used)
+SELECT tx_uid, account_id,
+       SUM(in_count) AS in_count,
+       SUM(out_count) AS out_count,
+       SUM(call_type_mask) AS call_type_mask,
+       SUM(value_in) AS value_in,
+       SUM(value_out) AS value_out,
+       0 AS gas_used
+FROM (
+    -- from-side: every internal call contributes to the caller's out_count.
+    -- call_type_mask stays 0 here since the mask only tracks incoming types.
+    SELECT tx_uid, from_id AS account_id,
+           0 AS in_count,
+           COUNT(*) AS out_count,
+           0 AS call_type_mask,
+           0 AS value_in,
+           SUM(value) AS value_out
+    FROM "el_transactions_internal"
+    GROUP BY tx_uid, from_id
+    UNION ALL
+    -- to-side: every internal call contributes to the callee's in_count.
+    -- SUM(DISTINCT 1<<call_type) reconstructs the bitmask of incoming types.
+    SELECT tx_uid, to_id AS account_id,
+           COUNT(*) AS in_count,
+           0 AS out_count,
+           SUM(DISTINCT (1 << call_type)) AS call_type_mask,
+           SUM(value) AS value_in,
+           0 AS value_out
+    FROM "el_transactions_internal"
+    GROUP BY tx_uid, to_id
+) sides
+GROUP BY tx_uid, account_id;
+
+DROP TABLE "el_transactions_internal";
+ALTER TABLE "el_transactions_internal_new" RENAME TO "el_transactions_internal";
+
+CREATE INDEX IF NOT EXISTS "el_internal_tx_account_idx"
+    ON "el_transactions_internal" ("account_id" ASC, "tx_uid" DESC);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/dbtypes/dbtypes.go
+++ b/dbtypes/dbtypes.go
@@ -491,15 +491,18 @@ type ElTransaction struct {
 	EffGasPrice float64 `db:"eff_gas_price"` // Effective gas price actually paid (in Gwei)
 }
 
-// ElTransactionInternal is a lightweight index of internal calls from call traces.
+// ElTransactionInternal is a per-account aggregate of internal calls within a
+// transaction. One row per (tx_uid, account_id) regardless of how many sub-
+// calls touched the account — keeps insert volume bounded for call-heavy txs.
 type ElTransactionInternal struct {
-	TxUid     uint64  `db:"tx_uid"`     // block_uid << 16 | tx_index
-	TxCallIdx uint32  `db:"tx_callidx"` // Depth-first traversal index (0=top-level, skipped)
-	CallType  uint8   `db:"call_type"`  // 0=CALL, 1=STATICCALL, 2=DELEGATECALL, 3=CREATE, 4=CREATE2, 5=SELFDESTRUCT
-	FromID    uint64  `db:"from_id"`
-	ToID      uint64  `db:"to_id"`
-	Value     float64 `db:"value"`
-	ValueRaw  []byte  `db:"value_raw"`
+	TxUid        uint64  `db:"tx_uid"`         // block_uid << 16 | tx_index
+	AccountID    uint64  `db:"account_id"`     // touched account (from, to, or both)
+	InCount      uint16  `db:"in_count"`       // calls where account = callee (clamped)
+	OutCount     uint16  `db:"out_count"`      // calls where account = caller (clamped)
+	CallTypeMask uint16  `db:"call_type_mask"` // bitmap of incoming call types (account = to-side): bit n = 1 << n
+	ValueIn      float64 `db:"value_in"`       // sum of value where account was callee (ETH)
+	ValueOut     float64 `db:"value_out"`      // sum of value where account was caller (ETH)
+	GasUsed      uint64  `db:"gas_used"`       // sum of gas_used across calls involving the account
 }
 
 // ElEventIndex is a lightweight searchable index for events (full data in blockdb).

--- a/handlers/address.go
+++ b/handlers/address.go
@@ -699,7 +699,7 @@ func calculateTxHashRowspans(transfers []*models.AddressPageDataTokenTransfer) {
 }
 
 func loadInternalTxsTab(ctx context.Context, pageData *models.AddressPageData, account *dbtypes.ElAccount, chainState *consensus.ChainState, offset uint64, limit uint32, pageIdx uint64) {
-	// Get internal transactions for this account
+	// Get per-tx aggregate rows where this account was involved
 	dbEntries, totalCount, _ := db.GetElTransactionsInternalByAccount(ctx, account.ID, offset, limit)
 
 	pageData.InternalTxCount = totalCount
@@ -709,15 +709,12 @@ func loadInternalTxsTab(ctx context.Context, pageData *models.AddressPageData, a
 	pageData.InternalTxFirstItem = (pageIdx-1)*uint64(limit) + 1
 	pageData.InternalTxLastItem = min(pageIdx*uint64(limit), totalCount)
 
-	// Collect account IDs, block UIDs, and tx UIDs for batch lookup
-	accountIDs := make(map[uint64]bool, len(dbEntries)*2)
+	// Collect block UIDs and tx UIDs for batch lookup (account_id is implicit = page address)
 	blockUidSet := make(map[uint64]bool, len(dbEntries))
 	blockUids := make([]uint64, 0, len(dbEntries))
 	txUidSet := make(map[uint64]bool, len(dbEntries))
 	txUids := make([]uint64, 0, len(dbEntries))
 	for _, e := range dbEntries {
-		accountIDs[e.FromID] = true
-		accountIDs[e.ToID] = true
 		blockUid := e.TxUid >> 16
 		if !blockUidSet[blockUid] {
 			blockUidSet[blockUid] = true
@@ -726,20 +723,6 @@ func loadInternalTxsTab(ctx context.Context, pageData *models.AddressPageData, a
 		if !txUidSet[e.TxUid] {
 			txUidSet[e.TxUid] = true
 			txUids = append(txUids, e.TxUid)
-		}
-	}
-
-	// Batch lookup accounts
-	accountIDList := make([]uint64, 0, len(accountIDs))
-	for id := range accountIDs {
-		accountIDList = append(accountIDList, id)
-	}
-	accountMap := make(map[uint64]*dbtypes.ElAccount, len(accountIDList))
-	if len(accountIDList) > 0 {
-		if accounts, err := db.GetElAccountsByIDs(ctx, accountIDList); err == nil {
-			for _, a := range accounts {
-				accountMap[a.ID] = a
-			}
 		}
 	}
 
@@ -768,16 +751,6 @@ func loadInternalTxsTab(ctx context.Context, pageData *models.AddressPageData, a
 		}
 	}
 
-	// Call type names
-	callTypeNames := map[uint8]string{
-		0: "CALL",
-		1: "STATICCALL",
-		2: "DELEGATECALL",
-		3: "CREATE",
-		4: "CREATE2",
-		5: "SELFDESTRUCT",
-	}
-
 	// Build internal transaction list
 	pageData.InternalTxs = make([]*models.AddressPageDataInternalTransaction, 0, len(dbEntries))
 	for _, e := range dbEntries {
@@ -786,25 +759,17 @@ func loadInternalTxsTab(ctx context.Context, pageData *models.AddressPageData, a
 		blockTime := chainState.SlotToTime(phase0.Slot(slot))
 
 		itx := &models.AddressPageDataInternalTransaction{
-			TxHash:     txHashMap[e.TxUid],
-			BlockUid:   blockUid,
-			BlockTime:  blockTime,
-			CallIndex:  e.TxCallIdx,
-			CallType:   e.CallType,
-			FromID:     e.FromID,
-			ToID:       e.ToID,
-			IsOutgoing: e.FromID == account.ID,
-			Amount:     e.Value,
-			AmountRaw:  e.ValueRaw,
+			TxHash:    txHashMap[e.TxUid],
+			BlockUid:  blockUid,
+			BlockTime: blockTime,
+			InCount:   e.InCount,
+			OutCount:  e.OutCount,
+			CallTypes: expandCallTypeMask(e.CallTypeMask),
+			ValueIn:   e.ValueIn,
+			ValueOut:  e.ValueOut,
+			GasUsed:   e.GasUsed,
 		}
 
-		if name, ok := callTypeNames[e.CallType]; ok {
-			itx.TypeName = name
-		} else {
-			itx.TypeName = fmt.Sprintf("TYPE_%d", e.CallType)
-		}
-
-		// Set block info
 		if blockInfo, ok := blockMap[blockUid]; ok && blockInfo.Block != nil {
 			itx.BlockRoot = blockInfo.Block.Root
 			itx.BlockOrphaned = blockInfo.Block.Status == dbtypes.Orphaned
@@ -813,47 +778,40 @@ func loadInternalTxsTab(ctx context.Context, pageData *models.AddressPageData, a
 			}
 		}
 
-		// Set addresses
-		if from, ok := accountMap[e.FromID]; ok {
-			itx.FromAddr = from.Address
-			itx.FromIsContract = from.IsContract
-		}
-		if to, ok := accountMap[e.ToID]; ok {
-			itx.ToAddr = to.Address
-			itx.ToIsContract = to.IsContract
-		}
-
 		pageData.InternalTxs = append(pageData.InternalTxs, itx)
 	}
-
-	// Calculate TxHashRowspan for consecutive internal txs with same txhash
-	calculateInternalTxHashRowspans(pageData.InternalTxs)
 }
 
-// calculateInternalTxHashRowspans sets TxHashRowspan for consecutive internal txs with the same txhash.
-// The first occurrence gets the rowspan count, subsequent occurrences get 0 (meaning skip rendering the cell).
-func calculateInternalTxHashRowspans(txs []*models.AddressPageDataInternalTransaction) {
-	if len(txs) == 0 {
-		return
+// callTypeBitNames maps a CallTypeMask bit position to its display name. Keep
+// in sync with exerpc.CallTypeFromString.
+var callTypeBitNames = []string{
+	"CALL",         // 0
+	"STATICCALL",   // 1
+	"DELEGATECALL", // 2
+	"CREATE",       // 3
+	"CREATE2",      // 4
+	"SELFDESTRUCT", // 5
+}
+
+func expandCallTypeMask(mask uint16) []models.AddressPageDataInternalTransactionCallType {
+	if mask == 0 {
+		return nil
 	}
-
-	i := len(txs) - 1
-	for i >= 0 {
-		currentTxHash := txs[i].TxHash
-		groupStart := i
-
-		for groupStart > 0 && bytes.Equal(txs[groupStart-1].TxHash, currentTxHash) {
-			groupStart--
+	types := make([]models.AddressPageDataInternalTransactionCallType, 0, 4)
+	for bit := uint8(0); bit < 16; bit++ {
+		if mask&(1<<bit) == 0 {
+			continue
 		}
-
-		rowspan := i - groupStart + 1
-		txs[groupStart].TxHashRowspan = rowspan
-		for j := groupStart + 1; j <= i; j++ {
-			txs[j].TxHashRowspan = 0
+		name := fmt.Sprintf("TYPE_%d", bit)
+		if int(bit) < len(callTypeBitNames) {
+			name = callTypeBitNames[bit]
 		}
-
-		i = groupStart - 1
+		types = append(types, models.AddressPageDataInternalTransactionCallType{
+			Type: bit,
+			Name: name,
+		})
 	}
+	return types
 }
 
 func loadWithdrawalsTab(ctx context.Context, pageData *models.AddressPageData, account *dbtypes.ElAccount, chainState *consensus.ChainState, limit uint32, pageIdx uint64) {

--- a/handlers/transaction.go
+++ b/handlers/transaction.go
@@ -1004,9 +1004,11 @@ func loadTransactionInternalTxsFromBlockdb(ctx context.Context, pageData *models
 		}
 	}
 
-	// Fallback: load from DB index (only when blockdb is unavailable)
-	entries, _ := db.GetElTransactionsInternalByTxUid(ctx, txUid)
-	loadTransactionInternalTxsFromDB(ctx, pageData, entries)
+	// No per-call detail in the DB index (it stores per-account aggregates),
+	// so when blockdb is unavailable we have nothing to render. Surface the
+	// "not available" state so the template shows the archive notice.
+	_ = txUid
+	pageData.InternalTxsNotAvailable = true
 }
 
 // buildInternalTxsFromBlockdb converts decoded blockdb call frames to page
@@ -1111,63 +1113,6 @@ func buildInternalTxsFromBlockdb(ctx context.Context, pageData *models.Transacti
 					}
 				}
 			}
-		}
-
-		pageData.InternalTxs = append(pageData.InternalTxs, itx)
-	}
-}
-
-// loadTransactionInternalTxsFromDB populates internal transactions from DB data
-// only (no depth/input/output trace data).
-func loadTransactionInternalTxsFromDB(ctx context.Context, pageData *models.TransactionPageData, entries []*dbtypes.ElTransactionInternal) {
-	if len(entries) == 0 {
-		return
-	}
-
-	// Collect account IDs for batch lookup
-	accountIDs := make(map[uint64]bool, len(entries)*2)
-	for _, e := range entries {
-		accountIDs[e.FromID] = true
-		accountIDs[e.ToID] = true
-	}
-
-	// Batch lookup accounts
-	accountIDList := make([]uint64, 0, len(accountIDs))
-	for id := range accountIDs {
-		accountIDList = append(accountIDList, id)
-	}
-	accountMap := make(map[uint64]*dbtypes.ElAccount, len(accountIDList))
-	if len(accountIDList) > 0 {
-		if accounts, err := db.GetElAccountsByIDs(ctx, accountIDList); err == nil {
-			for _, a := range accounts {
-				accountMap[a.ID] = a
-			}
-		}
-	}
-
-	// Build internal tx list
-	pageData.InternalTxs = make([]*models.TransactionPageDataInternalTx, 0, len(entries))
-	for _, e := range entries {
-		itx := &models.TransactionPageDataInternalTx{
-			CallIndex: e.TxCallIdx,
-			CallType:  e.CallType,
-			Amount:    e.Value,
-			AmountRaw: e.ValueRaw,
-		}
-
-		if name, ok := callTypeNames[e.CallType]; ok {
-			itx.TypeName = name
-		} else {
-			itx.TypeName = fmt.Sprintf("TYPE_%d", e.CallType)
-		}
-
-		if from, ok := accountMap[e.FromID]; ok {
-			itx.FromAddr = from.Address
-			itx.FromIsContract = from.IsContract
-		}
-		if to, ok := accountMap[e.ToID]; ok {
-			itx.ToAddr = to.Address
-			itx.ToIsContract = to.IsContract
 		}
 
 		pageData.InternalTxs = append(pageData.InternalTxs, itx)

--- a/indexer/execution/txindexer/process_transactions.go
+++ b/indexer/execution/txindexer/process_transactions.go
@@ -125,8 +125,8 @@ type txProcessingResult struct {
 	toAccount      *pendingAccount
 
 	// Call trace data (populated in Mode Full + tracesEnabled)
-	internalCalls []*pendingInternalCall
-	callTraceData []bdbtypes.FlatCallFrame // Flattened call trace for blockdb serialization
+	internalAggregates map[*pendingAccount]*pendingInternalAggregate
+	callTraceData      []bdbtypes.FlatCallFrame // Flattened call trace for blockdb serialization
 
 	// State changes data (populated in Mode Full + tracesEnabled)
 	stateChangesData []bdbtypes.StateChangeAccount
@@ -149,14 +149,17 @@ type pendingTxEvent struct {
 	data       []byte   // Event data
 }
 
-// pendingInternalCall represents an internal call extracted from a call trace.
-type pendingInternalCall struct {
-	txCallIdx   uint32
-	callType    uint8
-	fromAccount *pendingAccount
-	toAccount   *pendingAccount
-	value       float64
-	valueRaw    []byte
+// pendingInternalAggregate accumulates per-account internal-call stats for a
+// single transaction. One instance per touched account; updated as the call
+// tree is walked. Persisted as a single row in el_transactions_internal.
+type pendingInternalAggregate struct {
+	account      *pendingAccount
+	inCount      uint32  // calls where account = callee (clamped to uint16 max on flush)
+	outCount     uint32  // calls where account = caller (clamped to uint16 max on flush)
+	callTypeMask uint16  // bits 1<<n set when account was the callee of a CALL of type n
+	valueIn      float64 // sum of value when account was callee
+	valueOut     float64 // sum of value when account was caller
+	gasUsed      uint64  // sum of gas_used across calls involving the account
 }
 
 // pendingTokenTransfer represents a token transfer with references to its token and accounts.
@@ -340,7 +343,7 @@ func (ctx *txProcessingContext) processTransaction(
 
 	// 6. Process call trace if available (Mode Full + tracesEnabled)
 	if callTrace != nil {
-		result.callTraceData, result.internalCalls = ctx.processCallTrace(callTrace, fromAccount)
+		result.callTraceData, result.internalAggregates = ctx.processCallTrace(callTrace, fromAccount)
 	}
 
 	// 7. Process state diffs (storage changes) if available (Mode Full + tracesEnabled)
@@ -1147,18 +1150,28 @@ func (ctx *txProcessingContext) commitTransaction(commitCtx context.Context, dbT
 		}
 	}
 
-	// 6. Insert internal call index entries (Mode Full + tracesEnabled)
-	if ctx.indexer.mode == ModeFull && utils.Config.ExecutionIndexer.TracesEnabled && len(result.internalCalls) > 0 {
-		internalEntries := make([]*dbtypes.ElTransactionInternal, 0, len(result.internalCalls))
-		for _, ic := range result.internalCalls {
+	// 6. Insert per-account internal-tx aggregates (Mode Full + tracesEnabled).
+	// One row per touched account regardless of how many sub-calls involved it.
+	if ctx.indexer.mode == ModeFull && utils.Config.ExecutionIndexer.TracesEnabled && len(result.internalAggregates) > 0 {
+		internalEntries := make([]*dbtypes.ElTransactionInternal, 0, len(result.internalAggregates))
+		for _, agg := range result.internalAggregates {
+			inCount := agg.inCount
+			if inCount > 32767 {
+				inCount = 32767 // clamp to SMALLINT max (postgres int2 is signed)
+			}
+			outCount := agg.outCount
+			if outCount > 32767 {
+				outCount = 32767
+			}
 			internalEntries = append(internalEntries, &dbtypes.ElTransactionInternal{
-				TxUid:     result.transaction.TxUid,
-				TxCallIdx: ic.txCallIdx,
-				CallType:  ic.callType,
-				FromID:    ic.fromAccount.id,
-				ToID:      ic.toAccount.id,
-				Value:     ic.value,
-				ValueRaw:  ic.valueRaw,
+				TxUid:        result.transaction.TxUid,
+				AccountID:    agg.account.id,
+				InCount:      uint16(inCount),
+				OutCount:     uint16(outCount),
+				CallTypeMask: agg.callTypeMask,
+				ValueIn:      agg.valueIn,
+				ValueOut:     agg.valueOut,
+				GasUsed:      agg.gasUsed,
 			})
 		}
 
@@ -1172,18 +1185,28 @@ func (ctx *txProcessingContext) commitTransaction(commitCtx context.Context, dbT
 
 // processCallTrace processes a call trace result for a single transaction.
 // It flattens the nested call tree depth-first for blockdb serialization
-// and extracts internal calls (sub-calls, skipping index 0) for the DB index.
+// and builds per-account aggregates over sub-calls (skipping index 0) for
+// the DB index.
 func (ctx *txProcessingContext) processCallTrace(
 	traceResult *exerpc.CallTraceCall,
 	funderAccount *pendingAccount,
-) ([]bdbtypes.FlatCallFrame, []*pendingInternalCall) {
+) ([]bdbtypes.FlatCallFrame, map[*pendingAccount]*pendingInternalAggregate) {
 	if traceResult == nil {
 		return nil, nil
 	}
 
 	frames := make([]bdbtypes.FlatCallFrame, 0, 16)
-	internalCalls := make([]*pendingInternalCall, 0, 16)
+	aggregates := make(map[*pendingAccount]*pendingInternalAggregate, 8)
 	callIdx := uint32(0)
+
+	getAgg := func(acc *pendingAccount) *pendingInternalAggregate {
+		agg, ok := aggregates[acc]
+		if !ok {
+			agg = &pendingInternalAggregate{account: acc}
+			aggregates[acc] = agg
+		}
+		return agg
+	}
 
 	var walkTrace func(call *exerpc.CallTraceCall, depth uint16)
 	walkTrace = func(call *exerpc.CallTraceCall, depth uint16) {
@@ -1200,12 +1223,27 @@ func (ctx *txProcessingContext) processCallTrace(
 			}
 		}
 
+		// callTracer reports gasUsed cumulatively over the subtree, so summing
+		// it across frames double-counts nested execution. Compute the
+		// frame-local gas (this frame's execution only) by subtracting direct
+		// children's cumulative gasUsed. Saturating subtract guards against
+		// rounding/clamping quirks from non-Geth tracers.
+		selfGas := uint64(call.GasUsed)
+		for i := range call.Calls {
+			childGas := uint64(call.Calls[i].GasUsed)
+			if childGas >= selfGas {
+				selfGas = 0
+				break
+			}
+			selfGas -= childGas
+		}
+
 		// Build flat call frame for blockdb
 		frame := bdbtypes.FlatCallFrame{
 			Depth:   depth,
 			Type:    exerpc.CallTypeFromString(call.Type),
 			Gas:     uint64(call.Gas),
-			GasUsed: uint64(call.GasUsed),
+			GasUsed: selfGas,
 			Status:  status,
 			Input:   call.Input,
 			Output:  call.Output,
@@ -1218,25 +1256,40 @@ func (ctx *txProcessingContext) processCallTrace(
 
 		frames = append(frames, frame)
 
-		// Extract internal call for DB index (skip index 0 = top-level call,
-		// which duplicates el_transactions)
+		// Aggregate per touched account (skip index 0 = top-level call,
+		// which duplicates el_transactions).
 		if currentIdx > 0 {
 			fromAccount := ctx.ensureAccount(call.From, funderAccount, false)
 			toAccount := ctx.ensureAccount(call.To, fromAccount, false)
+			callType := exerpc.CallTypeFromString(call.Type)
+			gasUsed := selfGas
 
-			ic := &pendingInternalCall{
-				txCallIdx:   currentIdx,
-				callType:    exerpc.CallTypeFromString(call.Type),
-				fromAccount: fromAccount,
-				toAccount:   toAccount,
-			}
-
+			var value float64
 			if frame.Value.Sign() > 0 {
-				ic.value = weiToFloat(frame.Value.ToBig(), 18)
-				ic.valueRaw = frame.Value.Bytes()
+				value = weiToFloat(frame.Value.ToBig(), 18)
 			}
 
-			internalCalls = append(internalCalls, ic)
+			if fromAccount == toAccount {
+				// Self-call: account is both caller and callee, count both ways.
+				agg := getAgg(fromAccount)
+				agg.inCount++
+				agg.outCount++
+				agg.callTypeMask |= 1 << callType
+				agg.valueIn += value
+				agg.valueOut += value
+				agg.gasUsed += gasUsed
+			} else {
+				fromAgg := getAgg(fromAccount)
+				fromAgg.outCount++
+				fromAgg.valueOut += value
+				fromAgg.gasUsed += gasUsed
+
+				toAgg := getAgg(toAccount)
+				toAgg.inCount++
+				toAgg.callTypeMask |= 1 << callType
+				toAgg.valueIn += value
+				toAgg.gasUsed += gasUsed
+			}
 		}
 
 		// Recurse into child calls
@@ -1246,7 +1299,7 @@ func (ctx *txProcessingContext) processCallTrace(
 	}
 
 	walkTrace(traceResult, 0)
-	return frames, internalCalls
+	return frames, aggregates
 }
 
 // buildExecDataObject builds the per-block execution data object from collected

--- a/templates/address/internal_txs.html
+++ b/templates/address/internal_txs.html
@@ -8,77 +8,67 @@
             <th>Txn Hash</th>
             <th>Block</th>
             <th data-timecol="duration">Age</th>
-            <th>Type</th>
-            <th>From</th>
-            <th></th>
-            <th>To</th>
-            <th>Value</th>
+            <th>Types</th>
+            <th>In</th>
+            <th>Out</th>
+            <th>Eth In</th>
+            <th>Eth Out</th>
+            <th>Gas Used</th>
           </tr>
         </thead>
         <tbody>
           {{ if gt .InternalTxCount 0 }}
             {{ range .InternalTxs }}
               <tr>
-                {{ if gt .TxHashRowspan 0 }}
-                <td class="text-monospace align-top addr-cell"{{ if gt .TxHashRowspan 1 }} rowspan="{{ .TxHashRowspan }}"{{ end }}>
+                <td class="text-monospace addr-cell">
                   <a href="/tx/{{ formatHexBytes .TxHash }}" data-bs-toggle="tooltip" title="{{ formatHexBytes .TxHash }}">{{ formatEthHashShort .TxHash 6 }}</a>
                   <i class="fa fa-copy text-muted ms-1" role="button" data-bs-toggle="tooltip" title="Copy transaction hash" data-clipboard-text="{{ formatHexBytes .TxHash }}"></i>
                 </td>
-                <td class="align-top"{{ if gt .TxHashRowspan 1 }} rowspan="{{ .TxHashRowspan }}"{{ end }}>
+                <td>
                   {{ if gt (len .BlockRoot) 0 }}
                     <a href="/slot/0x{{ printf "%x" .BlockRoot }}">{{ formatAddCommas .BlockNumber }}</a>
                   {{ else }}
                     {{ formatAddCommas .BlockNumber }}
                   {{ end }}
                 </td>
-                <td class="align-top" data-timer="{{ .BlockTime.Unix }}"{{ if gt .TxHashRowspan 1 }} rowspan="{{ .TxHashRowspan }}"{{ end }}>
+                <td data-timer="{{ .BlockTime.Unix }}">
                   <span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ .BlockTime }}">{{ formatRecentTimeShort .BlockTime }}</span>
                 </td>
-                {{ end }}
                 <td>
-                  {{ if eq .CallType 0 }}
-                  <span class="badge text-bg-primary">{{ .TypeName }}</span>
-                  {{ else if eq .CallType 1 }}
-                  <span class="badge text-bg-info">{{ .TypeName }}</span>
-                  {{ else if eq .CallType 2 }}
-                  <span class="badge text-bg-warning">{{ .TypeName }}</span>
-                  {{ else if or (eq .CallType 3) (eq .CallType 4) }}
-                  <span class="badge text-bg-success">{{ .TypeName }}</span>
-                  {{ else if eq .CallType 5 }}
-                  <span class="badge text-bg-danger">{{ .TypeName }}</span>
-                  {{ else }}
-                  <span class="badge text-bg-secondary">{{ .TypeName }}</span>
+                  {{ range .CallTypes }}
+                    {{ if eq .Type 0 }}
+                    <span class="badge text-bg-primary">{{ .Name }}</span>
+                    {{ else if eq .Type 1 }}
+                    <span class="badge text-bg-info">{{ .Name }}</span>
+                    {{ else if eq .Type 2 }}
+                    <span class="badge text-bg-warning">{{ .Name }}</span>
+                    {{ else if or (eq .Type 3) (eq .Type 4) }}
+                    <span class="badge text-bg-success">{{ .Name }}</span>
+                    {{ else if eq .Type 5 }}
+                    <span class="badge text-bg-danger">{{ .Name }}</span>
+                    {{ else }}
+                    <span class="badge text-bg-secondary">{{ .Name }}</span>
+                    {{ end }}
                   {{ end }}
                 </td>
-                <td class="text-monospace addr-cell">
-                  {{ if eq (printf "%x" .FromAddr) (printf "%x" $.Address) }}
-                    {{ formatEthAddressShort .FromAddr }}
-                  {{ else }}
-                    {{ formatEthAddressShortLink .FromAddr .FromIsContract }}
-                  {{ end }}
-                  <i class="fa fa-copy text-muted ms-1" role="button" data-bs-toggle="tooltip" title="Copy address" data-clipboard-text="{{ formatEthAddressFull .FromAddr }}"></i>
+                <td>
+                  {{ if gt .InCount 0 }}{{ formatNumber .InCount }}{{ else }}<span class="text-muted">—</span>{{ end }}
                 </td>
-                <td class="text-center">
-                  {{ if .IsOutgoing }}
-                    <span class="badge text-bg-warning">OUT</span>
-                  {{ else }}
-                    <span class="badge text-bg-success">IN</span>
-                  {{ end }}
+                <td>
+                  {{ if gt .OutCount 0 }}{{ formatNumber .OutCount }}{{ else }}<span class="text-muted">—</span>{{ end }}
                 </td>
-                <td class="text-monospace addr-cell">
-                  {{ if eq (printf "%x" .ToAddr) (printf "%x" $.Address) }}
-                    {{ formatEthAddressShort .ToAddr }}
-                  {{ else }}
-                    {{ formatEthAddressShortLink .ToAddr .ToIsContract }}
-                  {{ end }}
-                  <i class="fa fa-copy text-muted ms-1" role="button" data-bs-toggle="tooltip" title="Copy address" data-clipboard-text="{{ formatEthAddressFull .ToAddr }}"></i>
+                <td class="text-nowrap">
+                  {{ if gt .ValueIn 0.0 }}{{ formatTransactionValue .ValueIn }}{{ else }}<span class="text-muted">—</span>{{ end }}
                 </td>
-                <td class="text-nowrap">{{ formatTransactionValue .Amount }}</td>
+                <td class="text-nowrap">
+                  {{ if gt .ValueOut 0.0 }}{{ formatTransactionValue .ValueOut }}{{ else }}<span class="text-muted">—</span>{{ end }}
+                </td>
+                <td class="text-nowrap">{{ formatAddCommas .GasUsed }}</td>
               </tr>
             {{ end }}
           {{ else }}
             <tr>
-              <td colspan="8" class="text-center py-4 text-muted">
+              <td colspan="9" class="text-center py-4 text-muted">
                 <i class="fas fa-inbox fa-2x mb-2"></i>
                 <br>No internal transactions found
               </td>

--- a/types/models/address.go
+++ b/types/models/address.go
@@ -153,27 +153,28 @@ type AddressPageDataTokenTransfer struct {
 	MethodName     string    `json:"method_name"` // Function name if known
 }
 
-// AddressPageDataInternalTransaction represents an internal transaction for the address page
+// AddressPageDataInternalTransaction is a per-transaction aggregate of
+// internal calls touching the address. One row per tx (not per call).
 type AddressPageDataInternalTransaction struct {
-	TxHash         []byte    `json:"tx_hash" ssz-size:"32"`
-	TxHashRowspan  int       `json:"tx_hash_rowspan"` // >0 means render with rowspan, 0 means skip cell
-	BlockNumber    uint64    `json:"block_number"`
-	BlockUid       uint64    `json:"block_uid"`
-	BlockRoot      []byte    `json:"block_root" ssz-size:"32"`
-	BlockOrphaned  bool      `json:"block_orphaned"`
-	BlockTime      time.Time `json:"block_time"`
-	CallIndex      uint32    `json:"call_index"`
-	CallType       uint8     `json:"call_type"`
-	TypeName       string    `json:"type_name"`
-	FromAddr       []byte    `json:"from_addr" ssz-size:"20"`
-	FromID         uint64    `json:"from_id"`
-	FromIsContract bool      `json:"from_is_contract"`
-	ToAddr         []byte    `json:"to_addr" ssz-size:"20"`
-	ToID           uint64    `json:"to_id"`
-	ToIsContract   bool      `json:"to_is_contract"`
-	IsOutgoing     bool      `json:"is_outgoing"`
-	Amount         float64   `json:"amount"`
-	AmountRaw      []byte    `json:"amount_raw" ssz-size:"32"`
+	TxHash        []byte                                       `json:"tx_hash" ssz-size:"32"`
+	BlockNumber   uint64                                       `json:"block_number"`
+	BlockUid      uint64                                       `json:"block_uid"`
+	BlockRoot     []byte                                       `json:"block_root" ssz-size:"32"`
+	BlockOrphaned bool                                         `json:"block_orphaned"`
+	BlockTime     time.Time                                    `json:"block_time"`
+	InCount       uint16                                       `json:"in_count"`   // calls where address was callee
+	OutCount      uint16                                       `json:"out_count"`  // calls where address was caller
+	CallTypes     []AddressPageDataInternalTransactionCallType `json:"call_types"` // pre-expanded incoming call types
+	ValueIn       float64                                      `json:"value_in"`
+	ValueOut      float64                                      `json:"value_out"`
+	GasUsed       uint64                                       `json:"gas_used"`
+}
+
+// AddressPageDataInternalTransactionCallType is a single bit of CallTypeMask
+// expanded for template rendering.
+type AddressPageDataInternalTransactionCallType struct {
+	Type uint8  `json:"type"` // 0=CALL, 1=STATICCALL, 2=DELEGATECALL, 3=CREATE, 4=CREATE2, 5=SELFDESTRUCT
+	Name string `json:"name"`
 }
 
 // AddressPageDataWithdrawal represents a beacon withdrawal on the address page.


### PR DESCRIPTION
## Summary

Rewrites `el_transactions_internal` from a per-call-frame index (one row per sub-call) into a per-account aggregate (one row per touched account per transaction). Heavy-call transactions — e.g. a contract that fans 100 sub-calls into the same address, or a multisend with many recipients — drop from ~100 rows to a handful, eliminating the SQLite insert-pressure issue (~80k inserts/slot observed on busy devnets). The address-page "Internal Txs" tab now shows aggregated per-direction call counts and value/gas totals instead of one row per call frame.

## Changes

### Schema & Data Model

- **`el_transactions_internal` rebuilt** with new layout, primary key `(tx_uid, account_id)`:

  | Column | Type | Description |
  |---|---|---|
  | `tx_uid` | INTEGER | `block_uid << 16 \| tx_index` |
  | `account_id` | INTEGER | touched account (from, to, or both) |
  | `in_count` | SMALLINT | calls where account was the callee |
  | `out_count` | SMALLINT | calls where account was the caller |
  | `call_type_mask` | SMALLINT | bitmap of *incoming* call types — bit n = `1 << CallType_n` (CALL=0, STATICCALL=1, DELEGATECALL=2, CREATE=3, CREATE2=4, SELFDESTRUCT=5) |
  | `value_in` | REAL | sum of ETH received (account was callee) |
  | `value_out` | REAL | sum of ETH sent (account was caller) |
  | `gas_used` | INTEGER | sum of frame-local gas across calls involving the account |

- **Single composite index** `(account_id ASC, tx_uid DESC)` replaces the four old per-direction indexes (`from_id` + `to_id`, each with and without `tx_uid`).

- **Migration** (`20260519000000_internal-tx-aggregate.sql`, both engines): rebuilds the table from the old per-call layout. Historical data is aggregated in SQL:
  - From-side `out_count = COUNT(*)` per `(tx_uid, from_id)`, contributes to `value_out`.
  - To-side `in_count = COUNT(*)` per `(tx_uid, to_id)`, contributes to `value_in`.
  - `call_type_mask` reconstructed via `SUM(DISTINCT 1 << call_type)` — since each call type maps to a distinct power of two, summing distinct values is equivalent to bitwise OR (portable across SQLite and Postgres, no `BIT_OR` aggregate required).
  - `gas_used` zeroed for migrated rows (the old schema didn't store it); repopulates as the indexer touches new blocks.

### Indexer (`txindexer/process_transactions.go`)

- `pendingInternalCall` (one struct per sub-call) replaced with `pendingInternalAggregate` (one struct per touched account, accumulated as the call tree is walked).
- `processCallTrace` now builds a `map[*pendingAccount]*pendingInternalAggregate` during the depth-first walk:
  - Non-self call `A → B`: `A.outCount++`, `B.inCount++`, `B.callTypeMask |= 1<<type`, value/gas attributed both sides.
  - Self call `A → A`: `inCount++` and `outCount++` on the single row, mask bit set, value/gas attributed once.
  - Top-level frame (idx 0) is skipped — it duplicates `el_transactions`.
- `inCount` / `outCount` clamped to 32767 (postgres `SMALLINT` signed max) on insert.
- Insert uses upsert (`INSERT OR REPLACE` for SQLite, `ON CONFLICT (tx_uid, account_id) DO UPDATE` for Postgres) so re-indexed blocks overwrite cleanly.

### Frame-Local Gas Fix

`debug_traceBlockByHash` (callTracer) returns `gasUsed` per frame as a **cumulative subtree total**. Summing it across frames over-counts nested execution: a 3-deep chain attributing the same parent gas to every account it passes through. Fix:

```go
selfGas := uint64(call.GasUsed)
for i := range call.Calls {
    childGas := uint64(call.Calls[i].GasUsed)
    if childGas >= selfGas { selfGas = 0; break } // saturating
    selfGas -= childGas
}
```

Applied to **both**:
- the `gas_used` written into `el_transactions_internal` (aggregation correctness).
- the `GasUsed` stored in the blockdb `FlatCallFrame` (so the tx-detail "Internal Txs" tab shows the gas each frame's own execution consumed, not the inflated subtree total).

The saturating subtract guards against non-Geth tracers that may round `gasUsed` inconsistently.

### DB Layer (`db/el_transactions_internal.go`)

- `InsertElTransactionsInternal` rewritten to insert 8-field aggregate rows (was 7-field per-call rows).
- `GetElTransactionsInternalByAccount` is now a single direct index scan (`WHERE account_id = ?`) — the old query needed `UNION ALL` over `from_id` / `to_id` branches.
- `HasElTransactionsInternalByAccount` simplified to a single `EXISTS`.
- `GetElTransactionsInternalCountByTxUid` now counts distinct accounts touched by the tx (was: count of call frames). `GetElTransactionsInternalByTxUid` returns aggregate rows ordered by `account_id`.

### Address Page (`/address/{addr}?v=internaltxs`)

New columns:

| Tx Hash | Block | Age | Types | In | Out | Eth In | Eth Out | Gas Used |
|---|---|---|---|---|---|---|---|---|

- **In / Out** = `in_count` / `out_count` — number of internal calls hitting the address in each direction. Em-dash when zero.
- **Types** = badges expanded from `call_type_mask` (incoming-only). Lets staticcall/precompile interactions show "STATICCALL" even when no value transferred.
- **Eth In / Eth Out** = `value_in` / `value_out` formatted as ETH.
- **Gas Used** = aggregated frame-local gas.

One row per tx (no more `rowspan` grouping). `calculateInternalTxHashRowspans` removed.

### Transaction Page (`/tx/{hash}?v=internaltxs`)

- **Primary path unchanged**: rich per-frame call trace still rendered from blockdb (`FlatCallFrame` array).
- **DB fallback removed**: when blockdb is missing call-trace data (`ElBlockDataCallTraces` not set), the page now shows the "not available" archive notice instead of the old degraded per-call DB view — the DB index no longer holds per-call detail.
- Tab badge `Internal Txs (N)` shows account-count from `GetElTransactionsInternalCountByTxUid` on initial render; once the tab loads, blockdb data overwrites it with the actual call count.

### Models (`types/models/address.go`)

`AddressPageDataInternalTransaction` reshaped to mirror the aggregate row (`InCount`, `OutCount`, `CallTypes`, `ValueIn`, `ValueOut`, `GasUsed`). Added `AddressPageDataInternalTransactionCallType` helper struct for pre-expanded badge rendering. `TxHashRowspan` and per-call fields (`CallIndex`, `CallType`, `FromAddr`, `ToAddr`, `IsOutgoing`, …) removed.

## Impact

| Scenario | Before | After |
|---|---|---|
| 100-call loop to one contract | 100 rows + 4 index updates per row | 1–2 rows + 1 index update each |
| Multisend to 40 recipients | 40 rows | 41 rows (sender + 40 recipients), each with `in_count=1` or `out_count=40` |
| Precompile (`0x...0E`) called once per tx | 1 row per tx | 1 row per tx, `in_count=1` |
| `el_transactions_internal` storage | ~7 fields × N calls | ~8 fields × M accounts (M ≪ N for fan-out txs) |
