### PR TITLE
slot: preserve active tab when navigating between slots

### DIFF
--- a/templates/slot/slot.html
+++ b/templates/slot/slot.html
@@ -3,13 +3,13 @@
     <div class="d-md-flex py-2 justify-content-md-between">
       <h1 class="h4 my-2 mb-md-0 h1-pager">
         {{- if not (eq .Slot 0) -}}
-          <a href="/slot/{{ .PreviousSlot }}"><i class="fa fa-chevron-left"></i></a>
+          <a href="/slot/{{ .PreviousSlot }}" class="slot-nav-link" data-slot-nav-base="/slot/{{ .PreviousSlot }}"><i class="fa fa-chevron-left"></i></a>
         {{- else -}}
           <a></a>
         {{- end -}}
         <span><i class="fas fa-cube mx-2"></i>Slot <span id="slot">{{ .Slot }}</span></span>
         {{- if gt .NextSlot 0 -}}
-          <a href="/slot/{{ .NextSlot }}"><i class="fa fa-chevron-right"></i></a>
+          <a href="/slot/{{ .NextSlot }}" class="slot-nav-link" data-slot-nav-base="/slot/{{ .NextSlot }}"><i class="fa fa-chevron-right"></i></a>
         {{- else -}}
           <a></a>
         {{- end -}}
@@ -455,8 +455,20 @@
           if (target.length) target.tab('show');
         }
 
+        function syncSlotNavHashes() {
+          var hash = window.location.hash || '';
+          $('.slot-nav-link').each(function() {
+            var base = this.getAttribute('data-slot-nav-base') || this.getAttribute('href');
+            this.setAttribute('href', base + hash);
+          });
+        }
+
         activateTabByHash();
-        window.addEventListener('hashchange', activateTabByHash);
+        syncSlotNavHashes();
+        window.addEventListener('hashchange', function() {
+          activateTabByHash();
+          syncSlotNavHashes();
+        });
 
         $('.nav-tabs a[data-bs-toggle="tab"]').on('shown.bs.tab', function(e) {
           var href = e.target.getAttribute('href') || '';
@@ -464,6 +476,7 @@
           var newHash = href === '#overview' ? '' : href;
           if (window.location.hash !== newHash) {
             window.history.replaceState(null, document.title, window.location.pathname + window.location.search + newHash);
+            syncSlotNavHashes();
           }
         });
 


### PR DESCRIPTION
## Summary

When viewing a slot with a non-Overview tab open (e.g. `/slot/35#ptcVotes`), clicking the prev/next chevron used to drop the hash and land on `/slot/36` showing Overview. This made it tedious to compare the same tab across several slots.

The prev/next chevron anchors are tagged with a `slot-nav-link` class and the original path is stashed in `data-slot-nav-base`. A small JS helper rewrites their `href` to include `location.hash` on page load, on `hashchange`, and after a tab switch — so regular clicks, middle-clicks, and cmd-clicks all preserve the active tab.

A follow-up PR will address the brief Overview flash on uncached navigation (the page lands on the correct tab, but Bootstrap fades from Overview rather than starting on the target tab).

## Test plan

- [ ] On `/slot/<N>#ptcVotes`, click the right chevron → lands on `/slot/<N+1>#ptcVotes` with PTC Votes active.
- [ ] On `/slot/<N>#ptcVotes`, click the left chevron → lands on `/slot/<N-1>#ptcVotes` with PTC Votes active.
- [ ] Middle-click / cmd-click the chevrons → new tab opens with the hash preserved.
- [ ] Click a tab → URL hash updates; click Overview → hash clears.
- [ ] Navigate to a slot where the previously-open tab doesn't exist → falls back to Overview.