### PR TITLE
fix validatator name filter on missed slots

### DIFF
--- a/services/chainservice_blocks.go
+++ b/services/chainservice_blocks.go
@@ -1090,7 +1090,7 @@ func (bs *ChainService) GetDbBlocksByFilter(ctx context.Context, filter *dbtypes
 			filter.MinTxCount == nil && filter.MaxTxCount == nil && filter.MinBlobCount == nil && filter.MaxBlobCount == nil && len(filter.ForkIds) == 0 &&
 			filter.BuilderIndex == nil && filter.WithPayloadMask&dbtypes.PayloadStatusMaskMissing != 0 && len(filter.EthBlockParentHash) == 0 && filter.MinGasUsed == nil &&
 			filter.MaxGasUsed == nil && filter.MinGasLimit == nil && filter.MaxGasLimit == nil && filter.MinBlockSize == nil && filter.MaxBlockSize == nil &&
-			filter.WithMevBlock == 0 && filter.ProposerIndex == nil && filter.ProposerName == ""
+			filter.WithMevBlock == 0
 
 		// If filtering by slot, only check missing for that specific slot
 		if filter.Slot != nil {


### PR DESCRIPTION
# Show missed slots when filtering by proposer index or name

## Summary
- The `shouldCheckMissing` gate in `ChainService.GetDbBlocksByFilter` was disabling reconstruction of missed slots from epoch duties whenever a `ProposerIndex` or `ProposerName` filter was set, so the filtered slots view never showed missed slots for a specific validator.
- Proposer-based filters are evaluated against epoch duty assignments and are perfectly compatible with reconstructed missing slots — the extra terms were incorrect.
- Drop `filter.ProposerIndex == nil && filter.ProposerName == ""` from the `shouldCheckMissing` condition so missed slots appear for proposer-filtered queries.

## Root cause
Both terms were introduced unintentionally during a `master` → `gloas-support` merge conflict resolution in `128a7f66` ("Merge branch 'master' into gloas-support", Feb 10 2026). Two diverging tails of the `shouldCheckMissing` expression were concatenated *and* `&& filter.ProposerIndex == nil && filter.ProposerName == ""` was tacked on, with the whole tail duplicated. The duplication was cleaned up in a later commit, but the bogus proposer terms remained.
