### PR TITLE
fix: guard against nil validator on included_deposits page

### DIFF
--- a/handlers/included_deposits.go
+++ b/handlers/included_deposits.go
@@ -242,7 +242,9 @@ func buildFilteredIncludedDepositsPageData(ctx context.Context, pageIdx uint64, 
 			depositData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIdx))
 
 			validator := services.GlobalBeaconService.GetValidatorByIndex(validatorIdx, false)
-			if strings.HasPrefix(validator.Status.String(), "pending") {
+			if validator == nil {
+				depositData.ValidatorStatus = "Deposited"
+			} else if strings.HasPrefix(validator.Status.String(), "pending") {
 				depositData.ValidatorStatus = "Pending"
 			} else if validator.Status == v1.ValidatorStateActiveOngoing {
 				depositData.ValidatorStatus = "Active"


### PR DESCRIPTION
## Summary
- `GetValidatorByIndex` can legitimately return `nil` (e.g. when canonical head is unavailable or the dependent epoch state hasn't finished loading). `buildFilteredIncludedDepositsPageData` dereferenced the result without a nil check, which panics the whole page request.
- Added the same `validator == nil` guard that already exists in `handlers/deposits.go`, falling back to a `"Deposited"` status.
- Reproduced live on `dora.glamsterdam-devnet-4.ethpandaops.io/validators/included_deposits` (see screenshot in the issue thread).

## Crash log
```
goroutine 290434 [running]:
runtime/debug.Stack()
    /opt/hostedtoolcache/go/1.25.10/x64/src/runtime/debug/stack.go:26 +0x5e
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1.1()
    /home/runner/work/dora/dora/services/frontendcache.go:166 +0xd4
panic({0x2633a40?, 0x60ccdf0?})
    /opt/hostedtoolcache/go/1.25.10/x64/src/runtime/panic.go:783 +0x132
github.com/ethpandaops/dora/handlers.buildFilteredIncludedDepositsPageData({0x4cec7f0, 0xc00dcb3540}, 0x1, 0x32, 0x0, 0x0, {0x0, 0x0}, {0x0, 0x0}, ...)
    /home/runner/work/dora/dora/handlers/included_deposits.go:245 +0x1725
github.com/ethpandaops/dora/handlers.getFilteredIncludedDepositsPageData.func1(0xc0143bd980)
    /home/runner/work/dora/dora/handlers/included_deposits.go:107 +0xbd
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1(0x0?)
    /home/runner/work/dora/dora/services/frontendcache.go:211 +0x362
created by github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall in goroutine 280480
    /home/runner/work/dora/dora/services/frontendcache.go:160 +0x348
```

## Test plan
- [x] `go build ./...` passes locally
- [ ] Load `/validators/included_deposits` on a network where the prior request panicked — page renders, validators with unresolved state show `Deposited`