### PR TITLE
fix(indexer): populate ExecutionExtraData on Gloas+ blocks

### DIFF
--- a/indexer/beacon/block.go
+++ b/indexer/beacon/block.go
@@ -465,6 +465,7 @@ func (block *Block) setBlockIndex(body *all.SignedBeaconBlock, payload *all.Sign
 		blockIndex.EthTransactionCount = uint64(len(payload.Message.Payload.Transactions))
 		blockIndex.GasUsed = payload.Message.Payload.GasUsed
 		blockIndex.GasLimit = payload.Message.Payload.GasLimit
+		blockIndex.ExecutionExtraData = payload.Message.Payload.ExtraData
 	}
 
 	if blockSize, err := getBlockSize(block.dynSsz, body); err == nil {


### PR DESCRIPTION
## Summary
- On Gloas+ (EIP-7732) the execution payload moves to a separate envelope, so `body.ExecutionPayload` is nil and `getBlockExecutionExtraData(body)` returns `(nil, nil)`. The in-memory `BlockBodyIndex.ExecutionExtraData` was therefore always empty for post-Gloas blocks.
- This broke the **NOT** toggle on `/blocks/filtered` for the EL Extra Data filter: the inverted check short-circuits when `blockExtraData == ""` to "include empty/null extra data", so every cached block slipped through regardless of whether it matched the filter. The screenshot from glamsterdam-devnet-4 shows e.g. `f.extra=buildoor/ethrex 12.0.0` with NOT checked still returning rows whose extra data is exactly `buildoor/ethrex 12.0.0`.
- Fix: read `ExtraData` from `payload.Message.Payload.ExtraData` next to the other execution fields, mirroring what `writedb.go` already does for the DB-write path. Finalized rows in the slots table were not affected because the write path was already correct — only the unfinalized cache filter saw empty extra data.

## Test plan
- [x] Reproduce the bug on glamsterdam-devnet-4: `?f.extra=ethrex&f.einvert=on` includes `ethrex` rows.
- [x] Local devnet repro on a Gloas+ chain confirms the same behavior, and the debug log shows `blockExtraData=""` for cached blocks pre-fix.
- [x] After the fix: `blockExtraData="ethrex 13.0.0"`, `matches=true`, block is correctly skipped; result set contains only non-matching extra data.
- [x] Verify non-inverted filter still returns only matching rows.