### PR TITLE
Fix address transaction list missing rows on SQLite (`$N` placeholder ordering)

### DIFF
--- a/db/el_transactions.go
+++ b/db/el_transactions.go
@@ -309,7 +309,8 @@ func GetElTransactionsByAccountIDCombined(ctx context.Context, accountID uint64,
 	// NULLS LAST is required to match the index definition and enable index scans.
 	var sql strings.Builder
 	innerLimit := offset + uint64(limit)
-	args := []any{accountID, accountID, accountID, innerLimit}
+	// Placeholders must stay in ascending appearance order (see query_helpers.go).
+	args := []any{accountID, innerLimit, accountID, accountID, innerLimit}
 
 	fmt.Fprintf(&sql, `
 		SELECT %s
@@ -317,15 +318,15 @@ func GetElTransactionsByAccountIDCombined(ctx context.Context, accountID uint64,
 			SELECT * FROM (SELECT %s
 			FROM el_transactions WHERE from_id = $1
 			ORDER BY block_uid DESC NULLS LAST
-			LIMIT $4) AS a
+			LIMIT $2) AS a
 			UNION ALL
 			SELECT * FROM (SELECT %s
-			FROM el_transactions WHERE to_id = $2 AND from_id != $3
+			FROM el_transactions WHERE to_id = $3 AND from_id != $4
 			ORDER BY block_uid DESC NULLS LAST
-			LIMIT $4) AS b
+			LIMIT $5) AS b
 		) combined
 		ORDER BY tx_uid DESC
-		LIMIT $5`, elTransactionColumns, elTransactionColumns, elTransactionColumns)
+		LIMIT $6`, elTransactionColumns, elTransactionColumns, elTransactionColumns)
 	args = append(args, limit)
 
 	if offset > 0 {

--- a/db/forks.go
+++ b/db/forks.go
@@ -162,8 +162,8 @@ func GetForkVisualizationData(ctx context.Context, startSlot uint64, endSlot uin
 		FROM (
 			-- Forks that overlap with our time window
 			SELECT fork_id, base_slot, base_root, leaf_slot, leaf_root, parent_fork
-			FROM forks 
-			WHERE base_slot < $2 AND leaf_slot >= $1
+			FROM forks
+			WHERE leaf_slot >= $1 AND base_slot < $2
 			
 			UNION
 			
@@ -171,7 +171,7 @@ func GetForkVisualizationData(ctx context.Context, startSlot uint64, endSlot uin
 			SELECT p.fork_id, p.base_slot, p.base_root, p.leaf_slot, p.leaf_root, p.parent_fork
 			FROM forks p
 			INNER JOIN forks f ON p.fork_id = f.parent_fork
-			WHERE f.base_slot < $2 AND f.leaf_slot >= $1
+			WHERE f.leaf_slot >= $1 AND f.base_slot < $2
 			
 			UNION
 			
@@ -179,7 +179,7 @@ func GetForkVisualizationData(ctx context.Context, startSlot uint64, endSlot uin
 			SELECT c.fork_id, c.base_slot, c.base_root, c.leaf_slot, c.leaf_root, c.parent_fork
 			FROM forks c
 			INNER JOIN forks f ON c.parent_fork = f.fork_id
-			WHERE f.base_slot < $2 AND f.leaf_slot >= $1
+			WHERE f.leaf_slot >= $1 AND f.base_slot < $2
 		) AS combined_forks
 		ORDER BY base_slot ASC, fork_id ASC
 	`, startSlot, endSlot)

--- a/db/query_helpers.go
+++ b/db/query_helpers.go
@@ -1,5 +1,20 @@
 package db
 
+// IMPORTANT — $N placeholder ordering (SQLite vs PostgreSQL):
+//
+// PostgreSQL treats $N as a positional parameter: $1 is always the 1st arg,
+// $4 the 4th, regardless of where it appears in the query text.
+//
+// SQLite (mattn/go-sqlite3) treats $N as a *named* parameter. It assigns the
+// binding index by the order each distinct $N first appears in the query text,
+// NOT by the digit N. So a query that references e.g. $1, $4, $2, $3, $5 binds
+// the positional args in that appearance order, scrambling the values.
+//
+// Consequence: in queries that must run on both engines, placeholders MUST
+// appear in strict ascending order and a $N must not be reused out of position.
+// Give each value its own in-order placeholder (duplicating the arg if needed)
+// rather than reusing a lower number after a higher one.
+
 import (
 	"encoding/hex"
 	"fmt"


### PR DESCRIPTION
# Fix address transaction list missing rows on SQLite (`$N` placeholder ordering)

## Summary

Address pages on SQLite-backed instances could show only a handful of transactions
(e.g. **2 of 32**) even though every transaction was correctly indexed and the
displayed count was right. The cause is a SQL parameter-binding bug, not the
transaction indexer. This PR fixes the affected queries and documents the
underlying SQLite/PostgreSQL `$N` difference so it isn't reintroduced.

## Symptoms

- `/address/<addr>?v=transactions` showed far fewer rows than the header count
  (e.g. "Showing 1 - 25 of 32" but only 2 rows rendered; later pages empty).
- Internal transactions for the same address displayed fine.
- A fresh genesis re-sync of the **same** code appeared to "fix" it.
- Only SQLite instances were affected; PostgreSQL was correct.

## Root cause

`GetElTransactionsByAccountIDCombined` built its SQL with placeholders **out of
order and reusing `$4`**:

```sql
WHERE from_id = $1 ... LIMIT $4        -- $4 appears 2nd
WHERE to_id  = $2 AND from_id != $3 ... LIMIT $4
ORDER BY tx_uid DESC LIMIT $5
```

PostgreSQL treats `$N` as **positional** (`$4` is always the 4th arg), so this
worked there. SQLite (`mattn/go-sqlite3`) treats `$N` as a **named** parameter
and assigns each distinct name a bind index by its **order of first appearance**
in the query text — not by the digit `N`. Demonstration:

```
args passed in order: 10,20,30,40,50
$1=10  $4=20  $2=30  $3=40  $5=50   <- $4 received the 2nd arg
```

With first-appearance order `$1, $4, $2, $3, $5`, the positional args
`[accountID, accountID, accountID, innerLimit, limit]` were scrambled and the
**inner per-branch `LIMIT` was bound to `accountID`**. The branch effectively
became `LIMIT <accountID>`.

### Why it depended on account ID (and why a re-sync hid it)

The truncation is only visible when `account.ID < page size`:

| Instance              | account.ID | inner LIMIT became | rows shown |
| --------------------- | ---------- | ------------------ | ---------- |
| Live since genesis    | **2**      | `LIMIT 2`          | **2**      |
| Fresh genesis re-sync | **305**    | `LIMIT 305`        | 25/page    |

`el_accounts.id` is an autoincrement assigned in indexing order, so the same
address gets a different ID on a re-sync — which is why re-syncing masked the bug
without changing any code. The count query and the internal-transactions query
use separate, correctly-ordered statements, which is why the count stayed right
and internal txs displayed fine.

A second, latent instance of the same bug existed in
`GetForkVisualizationData` (`db/forks.go`): the predicate
`base_slot < $2 AND leaf_slot >= $1` placed `$2` before `$1`, silently inverting
the slot window on SQLite (it returned no overlapping forks).

## Changes

- **`db/el_transactions.go`** — renumbered placeholders in
  `GetElTransactionsByAccountIDCombined` to strict ascending appearance order
  (`$1…$6`); each inner `LIMIT` gets its own placeholder (the `innerLimit` value
  is passed twice).
- **`db/forks.go`** — reordered the window predicate to
  `leaf_slot >= $1 AND base_slot < $2` so `$1` appears before `$2`. (Reusing
  `$1`/`$2` across the three `UNION` branches is safe — only first-appearance
  order matters.)
- **`db/query_helpers.go`** — added a prominent note documenting the `$N`
  ordering rule for SQLite vs PostgreSQL so cross-engine queries keep placeholders
  in ascending appearance order.

## Verification

Reproduced and verified through the actual `mattn/go-sqlite3` driver against the
affected live database:

- Before: combined query returned **2** rows for the affected account.
- After: returns **25** rows (full page), matching a fresh re-sync.
- Forks predicate: before matched **0** overlapping forks; after matches
  correctly.
- `go build ./db/...` passes.

No re-sync is required — existing data is already correct; only the query was
reading it wrong. Rebuilding from this change restores correct display.

## Notes / follow-ups

- Static detection only catches single-literal SQL blocks. Queries assembled
  across multiple `fmt.Fprintf` calls (the common pattern in this package) are
  not caught statically. A follow-up could add a startup/test assertion that
  rejects out-of-order `$N` first-appearance, or migrate cross-engine queries to
  the `appendDollarPlaceholders` helpers which always emit in order.
