### PR TITLE
Fix nil-pointer panics on unloaded validators & exclude delegatecall value from internal tx aggregation

### DIFF
--- a/handlers/consolidations.go
+++ b/handlers/consolidations.go
@@ -190,7 +190,9 @@ func buildConsolidationsPageData(ctx context.Context, firstEpoch uint64, pageSiz
 				queueData.SourceEffectiveBalance = uint64(queueEntry.SrcValidator.Validator.EffectiveBalance)
 
 				validator := services.GlobalBeaconService.GetValidatorByIndex(queueEntry.SrcValidator.Index, false)
-				if strings.HasPrefix(validator.Status.String(), "pending") {
+				if validator == nil {
+					queueData.SourceValidatorStatus = "Unknown"
+				} else if strings.HasPrefix(validator.Status.String(), "pending") {
 					queueData.SourceValidatorStatus = "Pending"
 				} else if validator.Status == v1.ValidatorStateActiveOngoing {
 					queueData.SourceValidatorStatus = "Active"

--- a/handlers/initiated_deposits.go
+++ b/handlers/initiated_deposits.go
@@ -207,7 +207,9 @@ func buildFilteredInitiatedDepositsPageData(ctx context.Context, pageIdx uint64,
 			depositTxData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIdx))
 
 			validator := services.GlobalBeaconService.GetValidatorByIndex(validatorIdx, false)
-			if strings.HasPrefix(validator.Status.String(), "pending") {
+			if validator == nil {
+				depositTxData.ValidatorStatus = "Deposited"
+			} else if strings.HasPrefix(validator.Status.String(), "pending") {
 				depositTxData.ValidatorStatus = "Pending"
 			} else if validator.Status == v1.ValidatorStateActiveOngoing {
 				depositTxData.ValidatorStatus = "Active"

--- a/handlers/queued_consolidations.go
+++ b/handlers/queued_consolidations.go
@@ -179,7 +179,9 @@ func buildFilteredQueuedConsolidationsPageData(ctx context.Context, pageIdx uint
 			consolidationData.SourceEffectiveBalance = uint64(queueEntry.SrcValidator.Validator.EffectiveBalance)
 
 			validator := services.GlobalBeaconService.GetValidatorByIndex(queueEntry.SrcValidator.Index, false)
-			if strings.HasPrefix(validator.Status.String(), "pending") {
+			if validator == nil {
+				consolidationData.SourceValidatorStatus = "Unknown"
+			} else if strings.HasPrefix(validator.Status.String(), "pending") {
 				consolidationData.SourceValidatorStatus = "Pending"
 			} else if validator.Status == v1.ValidatorStateActiveOngoing {
 				consolidationData.SourceValidatorStatus = "Active"

--- a/handlers/queued_deposits.go
+++ b/handlers/queued_deposits.go
@@ -232,7 +232,9 @@ func buildQueuedDepositsPageData(ctx context.Context, pageIdx uint64, pageSize u
 			depositData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIdx))
 
 			validator := services.GlobalBeaconService.GetValidatorByIndex(validatorIdx, false)
-			if strings.HasPrefix(validator.Status.String(), "pending") {
+			if validator == nil {
+				depositData.ValidatorStatus = "Deposited"
+			} else if strings.HasPrefix(validator.Status.String(), "pending") {
 				depositData.ValidatorStatus = "Pending"
 			} else if validator.Status == v1.ValidatorStateActiveOngoing {
 				depositData.ValidatorStatus = "Active"

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -381,7 +381,9 @@ func buildValidatorPageData(ctx context.Context, validatorIndex uint64, tabView 
 				depositData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIdx))
 
 				validator := services.GlobalBeaconService.GetValidatorByIndex(validatorIdx, false)
-				if strings.HasPrefix(validator.Status.String(), "pending") {
+				if validator == nil {
+					depositData.ValidatorStatus = "Deposited"
+				} else if strings.HasPrefix(validator.Status.String(), "pending") {
 					depositData.ValidatorStatus = "Pending"
 				} else if validator.Status == v1.ValidatorStateActiveOngoing {
 					depositData.ValidatorStatus = "Active"

--- a/indexer/execution/txindexer/process_transactions.go
+++ b/indexer/execution/txindexer/process_transactions.go
@@ -1265,7 +1265,10 @@ func (ctx *txProcessingContext) processCallTrace(
 			gasUsed := selfGas
 
 			var value float64
-			if frame.Value.Sign() > 0 {
+			// DELEGATECALL executes the callee's code in the caller's context and
+			// never transfers value; the callTracer reports the inherited parent
+			// msg.value on the frame, so it must not be counted as transferred value.
+			if callType != bdbtypes.CallTypeDelegateCall && frame.Value.Sign() > 0 {
 				value = weiToFloat(frame.Value.ToBig(), 18)
 			}
 


### PR DESCRIPTION
# Fix nil-pointer panics on unloaded validators & exclude delegatecall value from internal tx aggregation

## Summary

This branch contains two independent fixes:

1. **Nil-pointer panics** when rendering deposit/consolidation pages before the validator set is loaded.
2. **Incorrect internal-transaction value accounting** for `DELEGATECALL` frames, which inflated reported incoming/outgoing value on affected addresses.

## Changes

### 1. Guard against unloaded validators (`handlers/`)

Several page builders called `GetValidatorByIndex(...)` and immediately dereferenced the result via `validator.Status.String()`. When the validator set is not yet loaded (or the validator index is not yet known on-chain), `GetValidatorByIndex` returns `nil`, causing a nil-pointer panic.

Each call site now checks for `nil` first and falls back to a sensible default status:

| File | Fallback status when `validator == nil` |
| --- | --- |
| `handlers/consolidations.go` | `"Unknown"` |
| `handlers/queued_consolidations.go` | `"Unknown"` |
| `handlers/initiated_deposits.go` | `"Deposited"` |
| `handlers/queued_deposits.go` | `"Deposited"` |
| `handlers/validator.go` | `"Deposited"` |

For deposits the validator may legitimately not exist yet (deposit submitted, validator not activated/known), so `"Deposited"` is the correct pre-activation state. For consolidation sources the validator is expected to exist, so `"Unknown"` flags the unexpected-but-non-fatal case.

### 2. Exclude `DELEGATECALL` value from internal tx aggregation (`indexer/execution/txindexer/process_transactions.go`)

A `DELEGATECALL` executes the callee's code in the **caller's** execution context and never transfers any ETH. However, geth's `callTracer` reports the *inherited* parent `msg.value` on the delegatecall frame. The per-account aggregation was reading that value and adding it to the callee's `valueIn` (and the caller's `valueOut`), inflating the reported incoming value of any address reached via delegatecall.

The value accounting now skips `DELEGATECALL` frames (reusing the existing `bdbtypes.CallTypeDelegateCall` constant). Such frames are still counted in `inCount`/`outCount` and the `callTypeMask` — only `valueIn`/`valueOut` are left untouched.

```go
var value float64
// DELEGATECALL executes the callee's code in the caller's context and
// never transfers value; the callTracer reports the inherited parent
// msg.value on the frame, so it must not be counted as transferred value.
if callType != bdbtypes.CallTypeDelegateCall && frame.Value.Sign() > 0 {
    value = weiToFloat(frame.Value.ToBig(), 18)
}
```

## Notes / Follow-ups

- The internal-tx fix only corrects **newly indexed** transactions. Already-stored `el_transactions_internal` rows would require a reindex to be corrected.

## Testing

- `go build ./...` passes.
