### PR TITLE
widen orphaned_epochs.eth_gas_used/limit to bigint

### DIFF
--- a/db/schema/pgsql/20260605120000_orphaned-epochs-gas-bigint.sql
+++ b/db/schema/pgsql/20260605120000_orphaned-epochs-gas-bigint.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- orphaned_epochs.eth_gas_used / eth_gas_limit were created as integer (Int4),
+-- but per-epoch sums exceed 2.147B (32 slots * ~100M gas). The matching
+-- columns on the canonical "epochs" table are bigint (migration
+-- 20250510232604); align orphaned_epochs to match.
+
+ALTER TABLE "orphaned_epochs"
+    ALTER COLUMN "eth_gas_used" TYPE bigint,
+    ALTER COLUMN "eth_gas_limit" TYPE bigint;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/db/schema/sqlite/20260605120000_orphaned-epochs-gas-bigint.sql
+++ b/db/schema/sqlite/20260605120000_orphaned-epochs-gas-bigint.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- No-op for sqlite: INTEGER affinity is already 64-bit. The matching pgsql
+-- migration widens orphaned_epochs.eth_gas_used / eth_gas_limit from Int4 to
+-- bigint to accommodate per-epoch gas sums above 2.147B.
+
+SELECT 1;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd


### PR DESCRIPTION
## Summary

- `orphaned_epochs.eth_gas_used` / `eth_gas_limit` were defined as `integer` (Int4, max 2,147,483,647) in `20250815021010_orphaned-epochs.sql`, but per-epoch gas sums easily exceed that (32 slots × ~100M gas ≈ 3.2B).
- The matching columns on the canonical `epochs` table were already widened to `bigint` by migration `20250510232604`; this just brings `orphaned_epochs` in line.
- Caught on glamsterdam-devnet-5 — cl-indexer was logging:

  ```
  level=error msg="error persisting orphaned epoch 169: 3040000000 is greater than maximum value for Int4" service=cl-indexer
  ```

- SQLite migration is a no-op (`SELECT 1`) since SQLite's INTEGER affinity is already 64-bit; kept in place to keep goose in sync across drivers.

## Test plan

- [ ] `goose -dir db/schema/pgsql postgres "$DSN" up` applies cleanly on a database where `20250815021010` has already been applied
- [ ] Verify columns: `\d orphaned_epochs` shows `eth_gas_used bigint` and `eth_gas_limit bigint`
- [ ] cl-indexer no longer logs `is greater than maximum value for Int4` for orphaned epochs with > 2.147B gas
- [ ] Fresh sqlite install applies the no-op without error