### PR TITLE
close IN() paren in GetMevBlocksByBlockHashes

### DIFF
--- a/db/mev_blocks.go
+++ b/db/mev_blocks.go
@@ -154,8 +154,7 @@ func GetMevBlocksByBlockHashes(ctx context.Context, blockHashes [][]byte) map[st
 	FROM mev_blocks
 	WHERE block_hash IN (`)
 	appendDollarPlaceholders(&sql, 1, len(blockHashes), ", ")
-	fmt.Fprint(&sql, `
-	`)
+	fmt.Fprint(&sql, ")")
 
 	mevBlocks := []*dbtypes.MevBlock{}
 	err := ReaderDb.SelectContext(ctx, &mevBlocks, sql.String(), queryArgs...)


### PR DESCRIPTION
## Summary

`db/mev_blocks.go:GetMevBlocksByBlockHashes` opens `WHERE block_hash IN (` then appends `$1, $2, …` placeholders, but the next `fmt.Fprint` only writes a trailing newline — the IN clause is never closed. Postgres rejects the query with:

```
Error while fetching MEV blocks by hashes: ERROR: syntax error at end of input (SQLSTATE 42601)
```

Caught on glamsterdam-devnet-5 with `module=db` spamming this 51 times in a 6-hour window. Every other call site of `appendDollarPlaceholders` in `db/` closes with `fmt.Fprint(&sql, ")")` (see `db/el_accounts.go`, `db/el_transactions.go`, `db/el_blocks.go`, `db/consolidation_request_txs.go`, `db/deposit_txs.go`). This brings `mev_blocks.go` in line.

## Test plan

- [x] `go build ./db/` clean
- [ ] Deploy and confirm `module=db` no longer logs `syntax error at end of input` for MEV block hash lookups
- [ ] MEV block detail pages still resolve correctly (positive case — paren closes around real placeholders)