### PR TITLE
demote cgc-decode failure from error to warn

### DIFF
--- a/handlers/clients_cl.go
+++ b/handlers/clients_cl.go
@@ -500,7 +500,7 @@ func buildCLClientsPageData(sortOrder string) (*models.ClientsCLPageData, time.D
 		if cgcHex, ok := enrValues["cgc"]; ok {
 			val, err := strconv.ParseUint(cgcHex.(string), 0, 64)
 			if err != nil {
-				logrus.WithFields(logrus.Fields{"node": v.Alias, "peer_id": v.PeerID, "cgc": cgcHex.(string)}).Error("failed to decode cgc. ", err)
+				logrus.WithFields(logrus.Fields{"node": v.Alias, "peer_id": v.PeerID, "cgc": cgcHex.(string)}).Warn("failed to decode cgc. ", err)
 			} else {
 				custodySubnetCount = val
 			}


### PR DESCRIPTION
## Summary

`handlers/clients_cl.go:503` logs `failed to decode cgc.` at `Error` when an external peer's ENR carries a malformed `cgc` (Custody Group Count) value. That's a peer-side bug — dora is reading the ENR correctly and rejecting an invalid value — so it shouldn't surface as `error` in the local node's logs.

## Why

Caught on glamsterdam-devnet-5:

```
level=error msg="failed to decode cgc. strconv.ParseUint: parsing \"0x\": invalid syntax"
  cgc=0x
  node=16Uiu2HAmLLJVnQpJx1eXz2LjVBrGnhHGPWGP4sgXvwREfFPy2Emt
  peer_id=16Uiu2HAmLLJVnQpJx1eXz2LjVBrGnhHGPWGP4sgXvwREfFPy2Emt
```

Tracing the peer (135.125.119.2:4001, OVH NL) through ClickHouse-shipped grandine / erigon logs:

- libp2p agent string: `erigon/caplin` (Erigon's embedded CL).
- Status message: `head_slot=0`, `head_root == finalized_root` (stalled), `peer custody columns: {}` — empty CGC matches the `cgc=0x` ENR field.
- Erigon's own caplin scoring kicks the peer out within seconds: `is bad peer ... bad responses scorer: peer exceeded bad responses threshold: got 5, threshold 5`.

So an external Caplin node is publishing a spec-invalid `cgc` and the rest of the network already recognises it as bad. The real fix lives upstream in `erigontech/erigon`. Dora's job here is to skip the value and move on, which it does — the `Error` log level is misleading.

## Change

Demote `Error` → `Warn` on the parse-failure path. Fields/format unchanged so log scrapers keep working. The `else` branch (CGC field missing entirely) still aggregates into `MissingCGCFromENRPeers` warnings as before.

## Test plan

- [x] `go build ./handlers/` clean
- [ ] Deploy and confirm `level=warn` (not `error`) for peers advertising malformed `cgc`
- [ ] Peers with a valid `cgc` continue to populate `custodySubnetCount` as before