### PR TITLE
fix builder name lookup in slot bids table

### DIFF
--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -1350,7 +1350,7 @@ func getSlotPageBids(pageData *models.SlotPageBlockData, blockSlot phase0.Slot) 
 			FeeRecipient: bid.FeeRecipient,
 			GasLimit:     bid.GasLimit,
 			BuilderIndex: uint64(bid.BuilderIndex),
-			BuilderName:  services.GlobalBeaconService.GetValidatorName(uint64(bid.BuilderIndex)),
+			BuilderName:  services.GlobalBeaconService.GetValidatorName(uint64(bid.BuilderIndex) | services.BuilderIndexFlag),
 			IsSelfBuilt:  bid.BuilderIndex < 0,
 			Slot:         bid.Slot,
 			Value:        bid.Value,


### PR DESCRIPTION
## Summary
- The slot page bids table resolved `BuilderName` via `GetValidatorName(BuilderIndex)` without OR'ing `services.BuilderIndexFlag`, so builder N got pulled from the validator-name namespace and surfaced validator N's name (e.g. builder 500 displayed as `lodestar-ethrex-1 (500)` because that's validator 500's kurtosis label).
- Every other call site that resolves a builder name already namespaces with the flag (`handlers/slot.go:792`, `handlers/slots.go:320`, `handlers/slots_filtered.go:569`, `handlers/blocks.go:311`, `handlers/api/slot_payload_header_v1.go:125`). This brings `getSlotPageBids` in line.

## Test plan
- [ ] On a Glamsterdam-style devnet, open a slot page with bids and confirm the Builder column no longer shows a validator's name for builders that don't have a registered builder name.
- [ ] Click the builder link — should still route to `/builder/<index>` (link target was already correct; only the displayed name was wrong).