### PR TITLE
drop redundant builder-index tooltip clashing with buildoor link

### DIFF
--- a/utils/format.go
+++ b/utils/format.go
@@ -872,7 +872,7 @@ func formatBuilder(index uint64, name string, externalURL string, icon string, w
 		} else {
 			nameLabel = html.EscapeString(name)
 		}
-		return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-name\" data-bs-toggle=\"tooltip\" data-bs-placement=\"top\" data-bs-title=\"%v\"><i class=\"fas %v\"></i> <a href=\"/builder/%v\">%v</a>%v</span>", index, icon, index, nameLabel, externalLink))
+		return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-name\"><i class=\"fas %v\"></i> <a href=\"/builder/%v\">%v</a>%v</span>", icon, index, nameLabel, externalLink))
 	}
 	return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-index\"><i class=\"fas %v\"></i> <a href=\"/builder/%v\">%v</a>%v</span>", icon, index, index, externalLink))
 }


### PR DESCRIPTION

<img width="878" height="410" alt="Screenshot 2026-06-05 at 17 15 10" src="https://github.com/user-attachments/assets/b2ba9edf-17d1-474a-a405-7a2b0fd71aa0" />
<img width="519" height="334" alt="Screenshot 2026-06-05 at 17 15 06" src="https://github.com/user-attachments/assets/4c4704d7-4aeb-4a03-b455-a3970f740b39" />


## Summary
- The builder name span carried a Bootstrap tooltip showing the index, but the index is already rendered inline as `name (index)`, and the adjacent external-link icon has its own `Open buildoor instance` tooltip
- The two tooltips overlapped on hover (see screenshot in linked issue) — drop the redundant one

## Test plan
- [ ] Hover over a builder link with both a name and a buildoor URL on a slot detail page → only the `Open buildoor instance` tooltip appears, no more overlapping `<index>` bubble
- [ ] Builders without a buildoor URL still link to `/builder/<index>` as before
- [ ] Self-built / no-name code paths unchanged