### PR TITLE
hack/devnet: wire buildoor inventory into generated dora config

### DIFF
--- a/.hack/devnet/run.sh
+++ b/.hack/devnet/run.sh
@@ -28,17 +28,31 @@ kurtosis files inspect "$ENCLAVE_NAME" el_cl_genesis_data "./genesis.json" | tai
 # Extract network name from config
 NETWORK_NAME=$(grep -E "^\s*network:" "${config_file}" | sed 's/.*network:\s*//' | tr -d '"'\'' ')
 
-# Determine validator names source based on network type
+# Determine validator names + buildoor inventory sources based on network type
 if [[ "$NETWORK_NAME" == *"devnet"* ]]; then
   # Use inventory API for devnet networks
   VALIDATOR_NAMES_CONFIG="validatorNamesInventory: \"https://config.${NETWORK_NAME}.ethpandaops.io/api/v1/nodes/validator-ranges\""
+  BUILDOOR_CONFIG="buildoorOverviewUrl: \"https://buildoor.${NETWORK_NAME}.ethpandaops.io\""
 else
   # Use local validator ranges file for all other networks
   VALIDATOR_NAMES_CONFIG="validatorNamesYaml: \"${__dir}/generated-validator-ranges.yaml\""
+  BUILDOOR_CONFIG=""
 fi
 
 ## Generate Dora config
 ENCLAVE_UUID=$(kurtosis enclave inspect "$ENCLAVE_NAME" --full-uuids | grep 'UUID:' | awk '{print $2}')
+
+# Local kurtosis buildoor container, when present, overrides the network-derived URL.
+BUILDOOR_CONTAINER=$(docker ps -aq -f "label=kurtosis_enclave_uuid=$ENCLAVE_UUID" \
+              -f "label=com.kurtosistech.app-id=kurtosis" \
+              -f "label=com.kurtosistech.id=buildoor" | head -1)
+if [ -n "$BUILDOOR_CONTAINER" ]; then
+  BUILDOOR_PORT=$(docker inspect --format='{{ (index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort }}' "$BUILDOOR_CONTAINER" 2>/dev/null)
+  if [ -n "$BUILDOOR_PORT" ]; then
+    BUILDOOR_CONFIG="buildoorUrls:
+    - \"http://127.0.0.1:${BUILDOOR_PORT}\""
+  fi
+fi
 
 BEACON_NODES=$(docker ps -aq -f "label=kurtosis_enclave_uuid=$ENCLAVE_UUID" \
               -f "label=com.kurtosistech.app-id=kurtosis" \
@@ -81,6 +95,7 @@ frontend:
   )"
   rainbowkitProjectId: "15fe4ab4d5c0bcb6f0dc7c398301ff0e"
   ${VALIDATOR_NAMES_CONFIG}
+  ${BUILDOOR_CONFIG}
   showSensitivePeerInfos: true
   showSubmitDeposit: true
   showSubmitElRequests: true


### PR DESCRIPTION
## Summary

Mirrors the validator-names pattern in run.sh so \`make devnet\` produces a generated dora config with \`buildoorOverviewUrl\` / \`buildoorUrls\` set automatically.

- **Named devnet** (\`network: <foo-devnet-N>\` in the kurtosis config) → \`buildoorOverviewUrl: https://buildoor.<network>.ethpandaops.io\` is emitted alongside the existing \`validatorNamesInventory\` for the same network.
- **Local kurtosis buildoor** (\`mev_type: buildoor\`) wins over the network-derived URL. The script discovers the \`buildoor\` enclave container, reads its host-published port for container port 8080, and emits \`buildoorUrls: ["http://127.0.0.1:<port>"]\`.
- Otherwise (named non-devnet network, no local buildoor) → \`\${BUILDOOR_CONFIG}\` expands to empty and the line is dropped.

Both modes drop a single line into the generated \`frontend:\` block — exactly the same plumbing model as \`\${VALIDATOR_NAMES_CONFIG}\`.

## Test plan

- [ ] \`make devnet\` against a \`network: glamsterdam-devnet-5\` config → generated \`frontend.buildoorOverviewUrl\` points at the live overview.
- [ ] \`make devnet\` against a local \`mev_type: buildoor\` config → generated \`frontend.buildoorUrls\` lists \`http://127.0.0.1:<port>\`.
- [ ] \`make devnet\` against a vanilla local devnet (no buildoor) → no buildoor line in the generated config.
- [ ] After \`make devnet-run\`, dora logs \`buildoor inventory refreshed: N resolved, M unresolved\` on the refresh interval; slot bids view shows the external-link icon.