### PR TITLE
fix loading blocks from blockdb

### DIFF
--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -286,6 +286,15 @@ func buildSlotPageData(ctx context.Context, blockSlot int64, blockRoot []byte) (
 
 	if blockData == nil {
 		pageData.Status = uint16(models.SlotStatusMissed)
+		// A canonical block is indexed for this slot but its contents could not be
+		// loaded from any client or the block db (e.g. all nodes checkpoint-synced
+		// past it). Surface this as "data unavailable" rather than "missed".
+		for _, sb := range slotBlocks {
+			if sb.Status == uint16(models.SlotStatusFound) && len(sb.BlockRoot) == 32 {
+				pageData.Status = uint16(models.SlotStatusDataUnavailable)
+				break
+			}
+		}
 		pageData.Proposer = math.MaxInt64
 		if epochStatsValues != nil {
 			if slotIndex := int(chainState.SlotToSlotIndex(slot)); slotIndex < len(epochStatsValues.ProposerDuties) {
@@ -831,6 +840,13 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 		}
 	} else {
 		executionPayload = body.ExecutionPayload
+	}
+
+	// Gloas+ block whose execution payload envelope couldn't be loaded from any
+	// client or the block db: mark the payload as unavailable (it may exist but we
+	// don't have it) rather than letting it render as a genuinely missing payload.
+	if blockData.Block.Version >= spec.DataVersionGloas && blockData.Payload == nil {
+		pageData.PayloadDataUnavailable = true
 	}
 
 	if executionPayload != nil {

--- a/services/chainservice_blocks.go
+++ b/services/chainservice_blocks.go
@@ -129,79 +129,83 @@ func (bs *ChainService) GetSlotDetailsByBlockroot(ctx context.Context, blockroot
 	}
 
 	// try loading from connected clients
+	// A header-load failure here is not fatal: no connected client has the block
+	// (e.g. after a checkpoint sync). We fall through to the block db below.
 	if result == nil {
-		err := loadBlockHeader()
-		if err != nil {
-			return nil, err
+		if err := loadBlockHeader(); err != nil {
+			logrus.WithError(err).Debugf("could not load block header for root 0x%x from clients", blockroot)
 		}
 
-		var block *all.SignedBeaconBlock
-		var payload *all.SignedExecutionPayloadEnvelope
-		bodyRetry := 0
-		for ; bodyRetry < 3; bodyRetry++ {
-			client := clients[bodyRetry%len(clients)]
-			if block == nil {
-				block, err = beacon.LoadBeaconBlock(ctx, client, blockroot)
-				if err != nil {
-					log := logrus.WithError(err)
-					if client != nil {
-						log = log.WithField("client", client.GetClient().GetName())
+		if header != nil {
+			var err error
+			var block *all.SignedBeaconBlock
+			var payload *all.SignedExecutionPayloadEnvelope
+			bodyRetry := 0
+			for ; bodyRetry < 3; bodyRetry++ {
+				client := clients[bodyRetry%len(clients)]
+				if block == nil {
+					block, err = beacon.LoadBeaconBlock(ctx, client, blockroot)
+					if err != nil {
+						log := logrus.WithError(err)
+						if client != nil {
+							log = log.WithField("client", client.GetClient().GetName())
+						}
+						log.Warnf("Error loading block body for root 0x%x", blockroot)
 					}
-					log.Warnf("Error loading block body for root 0x%x", blockroot)
 				}
-			}
 
-			if block != nil && block.Version >= spec.DataVersionGloas {
-				payload, err = beacon.LoadExecutionPayload(ctx, client, blockroot)
-				if payload != nil {
+				if block != nil && block.Version >= spec.DataVersionGloas {
+					payload, err = beacon.LoadExecutionPayload(ctx, client, blockroot)
+					if payload != nil {
+						break
+					} else if err != nil {
+						log := logrus.WithError(err)
+						if client != nil {
+							log = log.WithField("client", client.GetClient().GetName())
+						}
+						log.Warnf("Error loading block payload for root 0x%x", blockroot)
+					}
+				} else if block != nil {
 					break
-				} else if err != nil {
-					log := logrus.WithError(err)
-					if client != nil {
-						log = log.WithField("client", client.GetClient().GetName())
-					}
-					log.Warnf("Error loading block payload for root 0x%x", blockroot)
 				}
-			} else if block != nil {
-				break
 			}
-		}
-		if err == nil && block != nil {
-			result = &CombinedBlockResponse{
-				Root:     blockroot,
-				Header:   header,
-				Block:    block,
-				Payload:  payload,
-				Orphaned: false,
+			if err == nil && block != nil {
+				result = &CombinedBlockResponse{
+					Root:     blockroot,
+					Header:   header,
+					Block:    block,
+					Payload:  payload,
+					Orphaned: false,
+				}
 			}
 		}
 	}
 
-	// try loading from block db
-	if result == nil && header != nil && blockdb.GlobalBlockDb != nil {
-		blockData, err := blockdb.GlobalBlockDb.GetBlock(ctx, uint64(header.Message.Slot), blockroot[:],
-			btypes.BlockDataFlagBody|btypes.BlockDataFlagPayload|btypes.BlockDataFlagBal,
-			func(version uint64, block []byte) (any, error) {
-				return beacon.UnmarshalSignedBeaconBlockSSZ(bs.beaconIndexer.GetDynSSZ(), version, block)
-			}, func(version uint64, payload []byte) (any, error) {
-				return beacon.UnmarshalVersionedSignedExecutionPayloadEnvelopeSSZ(bs.beaconIndexer.GetDynSSZ(), version, payload)
-			})
-		if err == nil && blockData != nil && blockData.Body != nil {
-			resp := &CombinedBlockResponse{
-				Root:     blockroot,
-				Header:   header,
-				Block:    blockData.Body.(*all.SignedBeaconBlock),
-				Orphaned: false,
+	// fill any missing components (the whole block, or just the payload/BAL) from the
+	// long-term block db in a single request. This works even when no connected client
+	// still has the block (e.g. after all nodes checkpoint-synced past it). The slot
+	// needed to build the block db key is taken from the header when available,
+	// otherwise from our own db.
+	if blockdb.GlobalBlockDb != nil {
+		blockSlot := phase0.Slot(0)
+		haveSlot := false
+		switch {
+		case header != nil:
+			blockSlot, haveSlot = header.Message.Slot, true
+		case result != nil && result.Header != nil:
+			blockSlot, haveSlot = result.Header.Message.Slot, true
+		default:
+			if dbBlock := db.GetBlockHeadByRoot(ctx, blockroot[:]); dbBlock != nil {
+				blockSlot, haveSlot = phase0.Slot(dbBlock.Slot), true
 			}
-			if blockData.Payload != nil {
-				resp.Payload = blockData.Payload.(*all.SignedExecutionPayloadEnvelope)
+		}
+
+		if haveSlot {
+			completed, err := bs.completeBlockFromBlockDb(ctx, blockSlot, blockroot, header, result)
+			if err != nil {
+				return nil, err
 			}
-			if blockData.BalVersion != 0 && len(blockData.BalData) > 0 {
-				if bal, err := beacon.UnmarshalBlockAccessList(blockData.BalVersion, blockData.BalData); err == nil {
-					resp.BlockAccessList = bal
-				}
-			}
-			result = resp
+			result = completed
 		}
 	}
 
@@ -280,90 +284,169 @@ func (bs *ChainService) GetSlotDetailsBySlot(ctx context.Context, slot phase0.Sl
 	}
 
 	// try loading from connected clients
+	// A header-load failure here is not fatal: no connected client has the block
+	// (e.g. after a checkpoint sync). We fall through to the block db below.
 	if result == nil {
 		if header == nil {
-			err := loadBlockHeader()
-			if err != nil {
-				return nil, err
+			if err := loadBlockHeader(); err != nil {
+				logrus.WithError(err).Debugf("could not load block header for slot %v from clients", slot)
 			}
 		}
 
-		var err error
-		var block *all.SignedBeaconBlock
-		var payload *all.SignedExecutionPayloadEnvelope
-		bodyRetry := 0
-		for ; bodyRetry < 3; bodyRetry++ {
-			client := clients[bodyRetry%len(clients)]
-			block, err = beacon.LoadBeaconBlock(ctx, client, blockRoot)
-			if err != nil {
-				log := logrus.WithError(err)
-				if client != nil {
-					log = log.WithField("client", client.GetClient().GetName())
-				}
-				log.Warnf("Error loading block body for slot %v", slot)
-			}
-
-			if block != nil && block.Version >= spec.DataVersionGloas {
-				payload, err = beacon.LoadExecutionPayload(ctx, client, blockRoot)
-				if payload != nil {
-					break
-				} else if err != nil {
+		if header != nil {
+			var err error
+			var block *all.SignedBeaconBlock
+			var payload *all.SignedExecutionPayloadEnvelope
+			bodyRetry := 0
+			for ; bodyRetry < 3; bodyRetry++ {
+				client := clients[bodyRetry%len(clients)]
+				block, err = beacon.LoadBeaconBlock(ctx, client, blockRoot)
+				if err != nil {
 					log := logrus.WithError(err)
 					if client != nil {
 						log = log.WithField("client", client.GetClient().GetName())
 					}
-					log.Warnf("Error loading block payload for root 0x%x", blockRoot)
+					log.Warnf("Error loading block body for slot %v", slot)
 				}
-			} else if block != nil {
-				break
+
+				if block != nil && block.Version >= spec.DataVersionGloas {
+					payload, err = beacon.LoadExecutionPayload(ctx, client, blockRoot)
+					if payload != nil {
+						break
+					} else if err != nil {
+						log := logrus.WithError(err)
+						if client != nil {
+							log = log.WithField("client", client.GetClient().GetName())
+						}
+						log.Warnf("Error loading block payload for root 0x%x", blockRoot)
+					}
+				} else if block != nil {
+					break
+				}
 			}
-		}
-		if err == nil && block != nil {
-			result = &CombinedBlockResponse{
-				Root:     blockRoot,
-				Header:   header,
-				Block:    block,
-				Payload:  payload,
-				Orphaned: orphaned,
+			if err == nil && block != nil {
+				result = &CombinedBlockResponse{
+					Root:     blockRoot,
+					Header:   header,
+					Block:    block,
+					Payload:  payload,
+					Orphaned: orphaned,
+				}
 			}
 		}
 	}
 
-	// try loading from block db
-	if result == nil && header != nil && blockdb.GlobalBlockDb != nil {
-		blockData, err := blockdb.GlobalBlockDb.GetBlock(ctx, uint64(slot), blockRoot[:],
-			btypes.BlockDataFlagHeader|btypes.BlockDataFlagBody|btypes.BlockDataFlagPayload|btypes.BlockDataFlagBal,
-			func(version uint64, block []byte) (any, error) {
-				return beacon.UnmarshalSignedBeaconBlockSSZ(bs.beaconIndexer.GetDynSSZ(), version, block)
-			}, func(version uint64, payload []byte) (any, error) {
-				return beacon.UnmarshalVersionedSignedExecutionPayloadEnvelopeSSZ(bs.beaconIndexer.GetDynSSZ(), version, payload)
-			})
-		if err == nil && blockData != nil && blockData.Body != nil {
-			header := &phase0.SignedBeaconBlockHeader{}
-			err = header.UnmarshalSSZ(blockData.HeaderData)
+	// fill any missing components (the whole block, or just the payload/BAL) from the
+	// long-term block db in a single request. This works even when no connected client
+	// still has the block (e.g. after all nodes checkpoint-synced past it). When no
+	// client could serve the header the canonical block root is resolved from our own db.
+	if blockdb.GlobalBlockDb != nil {
+		if (blockRoot == phase0.Root{}) {
+			for _, dbBlock := range bs.GetDbBlocksForSlots(ctx, uint64(slot), 0, false, false) {
+				if dbBlock.Status == dbtypes.Canonical && len(dbBlock.Root) == 32 {
+					blockRoot = phase0.Root(dbBlock.Root)
+					break
+				}
+			}
+		}
+
+		if (blockRoot != phase0.Root{}) {
+			wasNil := result == nil
+			completed, err := bs.completeBlockFromBlockDb(ctx, slot, blockRoot, header, result)
 			if err != nil {
 				return nil, err
 			}
-
-			resp := &CombinedBlockResponse{
-				Root:     blockRoot,
-				Header:   header,
-				Block:    blockData.Body.(*all.SignedBeaconBlock),
-				Orphaned: false,
+			if wasNil && completed != nil {
+				completed.Orphaned = orphaned
 			}
-			if blockData.Payload != nil {
-				resp.Payload = blockData.Payload.(*all.SignedExecutionPayloadEnvelope)
-			}
-			if blockData.BalVersion != 0 && len(blockData.BalData) > 0 {
-				if bal, err := beacon.UnmarshalBlockAccessList(blockData.BalVersion, blockData.BalData); err == nil {
-					resp.BlockAccessList = bal
-				}
-			}
-			result = resp
+			result = completed
 		}
 	}
 
 	bs.populateBlockAccessList(ctx, result)
+
+	return result, nil
+}
+
+// completeBlockFromBlockDb fills any block components still missing in result from
+// the long-term block db (e.g. S3) using a single GetBlock request. When result is
+// nil it builds the whole response (header, body, payload and BAL) - this works even
+// when no connected client still has the block, e.g. after all nodes checkpoint-synced
+// past it. When result already holds a Gloas+ block whose execution payload could not
+// be loaded from any client, it fetches the payload (and BAL) in the same request.
+// slot and blockroot identify the block; header is used as the response header when
+// available, otherwise it is reconstructed from the header stored alongside the block.
+// Returns the (possibly newly created) result; result is left unchanged when the block
+// db is not configured or has nothing to add.
+func (bs *ChainService) completeBlockFromBlockDb(ctx context.Context, slot phase0.Slot, blockroot phase0.Root, header *phase0.SignedBeaconBlockHeader, result *CombinedBlockResponse) (*CombinedBlockResponse, error) {
+	if blockdb.GlobalBlockDb == nil {
+		return result, nil
+	}
+
+	// Determine which components are still missing and request them all at once.
+	var flags btypes.BlockDataFlags
+	if result == nil {
+		flags = btypes.BlockDataFlagHeader | btypes.BlockDataFlagBody | btypes.BlockDataFlagPayload | btypes.BlockDataFlagBal
+	} else if result.Block != nil && result.Block.Version >= spec.DataVersionGloas && result.Payload == nil {
+		// We have the block but its payload (and possibly the BAL stored with it)
+		// couldn't be loaded from a client.
+		flags = btypes.BlockDataFlagPayload | btypes.BlockDataFlagBal
+	}
+	if flags == 0 {
+		return result, nil
+	}
+
+	blockData, err := blockdb.GlobalBlockDb.GetBlock(ctx, uint64(slot), blockroot[:], flags,
+		func(version uint64, block []byte) (any, error) {
+			return beacon.UnmarshalSignedBeaconBlockSSZ(bs.beaconIndexer.GetDynSSZ(), version, block)
+		}, func(version uint64, payload []byte) (any, error) {
+			return beacon.UnmarshalVersionedSignedExecutionPayloadEnvelopeSSZ(bs.beaconIndexer.GetDynSSZ(), version, payload)
+		})
+	if err != nil || blockData == nil {
+		return result, err
+	}
+
+	// Build the response when no client had the block.
+	if result == nil {
+		if blockData.Body == nil {
+			return nil, nil
+		}
+
+		block, ok := blockData.Body.(*all.SignedBeaconBlock)
+		if !ok {
+			return nil, fmt.Errorf("unexpected block type %T loaded from blockdb", blockData.Body)
+		}
+
+		if header == nil && len(blockData.HeaderData) > 0 {
+			header = &phase0.SignedBeaconBlockHeader{}
+			if err := header.UnmarshalSSZ(blockData.HeaderData); err != nil {
+				return nil, fmt.Errorf("failed to decode block header from blockdb: %w", err)
+			}
+		}
+
+		result = &CombinedBlockResponse{
+			Root:     blockroot,
+			Header:   header,
+			Block:    block,
+			Orphaned: false,
+		}
+	}
+
+	// Fill in the payload if we received one and don't have it yet.
+	if result.Payload == nil && blockData.Payload != nil {
+		payload, ok := blockData.Payload.(*all.SignedExecutionPayloadEnvelope)
+		if !ok {
+			return result, fmt.Errorf("unexpected payload type %T loaded from blockdb", blockData.Payload)
+		}
+		result.Payload = payload
+	}
+
+	// Fill in the BAL if we received one and don't have it yet.
+	if len(result.BlockAccessList) == 0 && blockData.BalVersion != 0 && len(blockData.BalData) > 0 {
+		if bal, err := beacon.UnmarshalBlockAccessList(blockData.BalVersion, blockData.BalData); err == nil {
+			result.BlockAccessList = bal
+		}
+	}
 
 	return result, nil
 }

--- a/templates/slot/overview.html
+++ b/templates/slot/overview.html
@@ -71,6 +71,8 @@
             <span class="badge rounded-pill text-bg-success" style="font-size: 12px; font-weight: 500;">Proposed</span>
           {{ else if eq .Status 2 }}
             <span class="badge rounded-pill text-bg-info" style="font-size: 12px; font-weight: 500;">Missed (Orphaned)</span>
+          {{ else if eq .Status 3 }}
+            <span class="badge rounded-pill text-bg-secondary" style="font-size: 12px; font-weight: 500;" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="A canonical block was proposed for this slot, but its contents are currently unavailable from any connected client or the block store.">Proposed <i class="fas fa-question-circle ms-1"></i> Data Unavailable</span>
           {{ end }}
 
           {{ if .EpochFinalized }}
@@ -215,7 +217,9 @@
                 <div class="row py-1">
                   <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Block Number, the height, not the slot">Payload Status:</span></div>
                   <div class="col-md-10 text-monospace text-break">
-                    {{ if eq .PayloadStatus 0 }}
+                    {{ if $block.PayloadDataUnavailable }}
+                      <span class="badge rounded-pill text-bg-secondary" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="The execution payload envelope could not be loaded from any connected client or the block store. It may exist but is currently unavailable.">Data Unavailable</span>
+                    {{ else if eq .PayloadStatus 0 }}
                       <span class="badge rounded-pill text-bg-warning">Missing</span>
                     {{ else if eq .PayloadStatus 1 }}
                       <span class="badge rounded-pill text-bg-success">Revealed</span>

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -44,9 +44,10 @@ type SlotPageBlockBadge struct {
 type SlotStatus uint16
 
 const (
-	SlotStatusMissed   SlotStatus = 0
-	SlotStatusFound    SlotStatus = 1
-	SlotStatusOrphaned SlotStatus = 2
+	SlotStatusMissed          SlotStatus = 0
+	SlotStatusFound           SlotStatus = 1
+	SlotStatusOrphaned        SlotStatus = 2
+	SlotStatusDataUnavailable SlotStatus = 3
 )
 
 type SlotPageBlockData struct {
@@ -86,8 +87,9 @@ type SlotPageBlockData struct {
 	TargetCommitteeSize  uint64 `json:"target_committee_size"`
 	MaxCommitteesPerSlot uint64 `json:"max_committees_per_slot"`
 
-	PayloadHeader *SlotPagePayloadHeader `json:"payload_header"`
-	ExecutionData *SlotPageExecutionData `json:"execution_data"`
+	PayloadHeader          *SlotPagePayloadHeader `json:"payload_header"`
+	ExecutionData          *SlotPageExecutionData `json:"execution_data"`
+	PayloadDataUnavailable bool                   `json:"payload_data_unavailable"`
 
 	Attestations          []*SlotPageAttestation          `json:"attestations"`           // Attestations included in this block
 	Deposits              []*SlotPageDeposit              `json:"deposits"`               // Deposits included in this block


### PR DESCRIPTION
# Fix: load blocks from the block db when no node has them

## Problem

After an incident on `glamsterdam-devnet-5`, all beacon nodes were checkpoint-synced,
so none of them retained historic blocks in their local db. Opening a slot that was
still indexed in dora's own database (e.g. `/slot/8951`) rendered it as a **missed
block**, even though the block was present and fully intact in the S3 block db.

The block db (S3) is meant to be exactly this kind of long-term fallback, but the
fallback never ran.

## Root cause

Both block loaders in `services/chainservice_blocks.go` gated the S3 block-db fallback
behind a header that could only be obtained from a **live** beacon client:

1. `loadBlockHeader()` calls `LoadBeaconHeader` / `LoadBeaconHeaderBySlot` (a live RPC).
2. On failure both functions did `return nil, err` **before** reaching the block-db
   fallback.
3. Even if execution had continued, the fallback was additionally guarded by
   `header != nil`.

After a checkpoint sync no connected node has the historic header, so the loader
aborted and the block was reported as missed — despite being readable in S3.

The S3 object itself was verified to be valid and current-format: header, body,
payload and BAL all present, version words correctly encoding zlib compression, and
the component lengths matching the object size exactly. Nothing was wrong with the
stored data or the storage format.

## Changes

### `services/chainservice_blocks.go`

- **A header-load failure is no longer fatal.** When no client can serve the header
  the loader logs at debug level and falls through to the block db instead of
  returning an error. The client body-load is guarded behind `if header != nil`.
- **Single consolidated block-db request.** A new `completeBlockFromBlockDb` helper
  performs exactly one `GetBlock` call requesting only the components that are still
  missing:
  - no block at all → `Header | Body | Payload | BAL` (the body is parsed from SSZ,
    and the header is reconstructed from the stored header when no client provided
    one);
  - block present but its Gloas+ execution payload could not be loaded → `Payload | BAL`
    in the same request;
  - nothing missing → no request.

  This replaces the earlier approach that could hit S3 multiple times (separate body,
  payload and BAL fetches) for a single block.
- **Slot / root are resolved from dora's own db** (`GetBlockHeadByRoot` /
  `GetDbBlocksForSlots`) when no client can provide them, so the S3 object key can be
  built without a live node.

This makes both `GetSlotDetailsBySlot` and `GetSlotDetailsByBlockroot` able to serve
blocks purely from the block db.

### New "data unavailable" status (distinct from "missed")

When a canonical block is indexed for a slot but its contents cannot be loaded from
any client or the block db, the slot is no longer shown as *missed* — it is shown as
*proposed, data unavailable*. A genuinely missed slot (no block ever proposed) is
unchanged.

- `types/models/slot.go`: add `SlotStatusDataUnavailable` and a
  `PayloadDataUnavailable` flag on the block data.
- `handlers/slot.go`: set `SlotStatusDataUnavailable` when the db has a canonical
  block for the slot but the contents could not be loaded; set
  `PayloadDataUnavailable` for Gloas+ blocks whose execution payload envelope could
  not be loaded.
- `templates/slot/overview.html`: render the new slot status and a "Data Unavailable"
  payload-status badge (distinct from the existing "Missing" badge).

## Behavior after this change

- Historic slots that are still indexed but pruned from all nodes are served from the
  S3 block db instead of reported as missed.
- A block whose body came from a client but whose payload did not is completed from the
  block db in a single request.
- When the data genuinely cannot be loaded from anywhere, the UI distinguishes
  "data unavailable" (a block existed) from "missed" (no block was proposed), and
  "payload unavailable" from a genuinely missing payload.

## Testing

- `go build ./...` and `go vet ./services/... ./handlers/... ./types/...` pass.
- Verified directly against the S3 bucket that the affected block
  (`glamsterdam-devnet-5/000000/0000008951_f01edd0a`) is present and decodes
  correctly (header slot 8951, body/payload/BAL all decompress and parse).
