### PR TITLE
[codex] safe network overview

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -930,7 +930,7 @@ const docTemplate = `{
         },
         "/v1/network/overview": {
             "get": {
-                "description": "Returns the existing network overview data plus a safe health snapshot with current head slot, finality, validator counts, metadata, and provenance-aware aggregate data when available.",
+                "description": "Returns comprehensive network state information including network info, current state, checkpoints, validator stats, queue stats, fork information and a health snapshot with finality status, validator counts and provenance-aware participation data",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -930,7 +930,7 @@ const docTemplate = `{
         },
         "/v1/network/overview": {
             "get": {
-                "description": "Returns comprehensive network state information including network info, current state, checkpoints, validator stats, queue stats, and fork information",
+                "description": "Returns the existing network overview data plus a safe health snapshot with current head slot, finality, validator counts, metadata, and provenance-aware aggregate data when available.",
                 "consumes": [
                     "application/json"
                 ],
@@ -950,12 +950,9 @@ const docTemplate = `{
                         }
                     },
                     "500": {
-                        "description": "Internal server error",
+                        "description": "Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/api.ApiResponse"
                         }
                     }
                 }
@@ -3682,11 +3679,38 @@ const docTemplate = `{
         "api.APINetworkOverviewData": {
             "type": "object",
             "properties": {
+                "active_validator_count": {
+                    "type": "integer"
+                },
                 "checkpoints": {
                     "$ref": "#/definitions/api.APICheckpoints"
                 },
+                "current_epoch": {
+                    "type": "integer"
+                },
+                "current_slot": {
+                    "type": "integer"
+                },
                 "current_state": {
                     "$ref": "#/definitions/api.APICurrentState"
+                },
+                "data_quality_warnings": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "epochs_since_finality": {
+                    "type": "integer"
+                },
+                "exited_validator_count": {
+                    "type": "integer"
+                },
+                "finalized_epoch": {
+                    "type": "integer"
+                },
+                "finalizing": {
+                    "type": "boolean"
                 },
                 "forks": {
                     "type": "array",
@@ -3697,14 +3721,37 @@ const docTemplate = `{
                 "is_synced": {
                     "type": "boolean"
                 },
+                "metadata": {
+                    "$ref": "#/definitions/api.APINetworkOverviewMetadata"
+                },
                 "network_info": {
                     "$ref": "#/definitions/api.APINetworkInfo"
+                },
+                "participation": {
+                    "$ref": "#/definitions/api.APINetworkParticipation"
+                },
+                "pending_validator_count": {
+                    "type": "integer"
                 },
                 "queue_stats": {
                     "$ref": "#/definitions/api.APIQueueStats"
                 },
+                "raw_aggregates": {
+                    "$ref": "#/definitions/api.APINetworkRawAggregates"
+                },
+                "total_validator_count": {
+                    "type": "integer"
+                },
                 "validator_stats": {
                     "$ref": "#/definitions/api.APIValidatorStats"
+                }
+            }
+        },
+        "api.APINetworkOverviewMetadata": {
+            "type": "object",
+            "properties": {
+                "slots_per_epoch": {
+                    "type": "integer"
                 }
             }
         },
@@ -3716,6 +3763,55 @@ const docTemplate = `{
                 },
                 "status": {
                     "type": "string"
+                }
+            }
+        },
+        "api.APINetworkParticipation": {
+            "type": "object",
+            "properties": {
+                "complete": {
+                    "type": "boolean"
+                },
+                "expected_slots": {
+                    "type": "integer"
+                },
+                "indexed_slots": {
+                    "type": "integer"
+                },
+                "rate": {
+                    "type": "number"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "warning": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.APINetworkRawAggregates": {
+            "type": "object",
+            "properties": {
+                "attestations_indexed": {
+                    "type": "integer"
+                },
+                "complete": {
+                    "type": "boolean"
+                },
+                "expected_slots": {
+                    "type": "integer"
+                },
+                "globalparticipationrate": {
+                    "type": "number"
+                },
+                "indexed_slots": {
+                    "type": "integer"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "vote_participation": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -927,7 +927,7 @@
         },
         "/v1/network/overview": {
             "get": {
-                "description": "Returns comprehensive network state information including network info, current state, checkpoints, validator stats, queue stats, and fork information",
+                "description": "Returns the existing network overview data plus a safe health snapshot with current head slot, finality, validator counts, metadata, and provenance-aware aggregate data when available.",
                 "consumes": [
                     "application/json"
                 ],
@@ -947,12 +947,9 @@
                         }
                     },
                     "500": {
-                        "description": "Internal server error",
+                        "description": "Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/api.ApiResponse"
                         }
                     }
                 }
@@ -3679,11 +3676,38 @@
         "api.APINetworkOverviewData": {
             "type": "object",
             "properties": {
+                "active_validator_count": {
+                    "type": "integer"
+                },
                 "checkpoints": {
                     "$ref": "#/definitions/api.APICheckpoints"
                 },
+                "current_epoch": {
+                    "type": "integer"
+                },
+                "current_slot": {
+                    "type": "integer"
+                },
                 "current_state": {
                     "$ref": "#/definitions/api.APICurrentState"
+                },
+                "data_quality_warnings": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "epochs_since_finality": {
+                    "type": "integer"
+                },
+                "exited_validator_count": {
+                    "type": "integer"
+                },
+                "finalized_epoch": {
+                    "type": "integer"
+                },
+                "finalizing": {
+                    "type": "boolean"
                 },
                 "forks": {
                     "type": "array",
@@ -3694,14 +3718,37 @@
                 "is_synced": {
                     "type": "boolean"
                 },
+                "metadata": {
+                    "$ref": "#/definitions/api.APINetworkOverviewMetadata"
+                },
                 "network_info": {
                     "$ref": "#/definitions/api.APINetworkInfo"
+                },
+                "participation": {
+                    "$ref": "#/definitions/api.APINetworkParticipation"
+                },
+                "pending_validator_count": {
+                    "type": "integer"
                 },
                 "queue_stats": {
                     "$ref": "#/definitions/api.APIQueueStats"
                 },
+                "raw_aggregates": {
+                    "$ref": "#/definitions/api.APINetworkRawAggregates"
+                },
+                "total_validator_count": {
+                    "type": "integer"
+                },
                 "validator_stats": {
                     "$ref": "#/definitions/api.APIValidatorStats"
+                }
+            }
+        },
+        "api.APINetworkOverviewMetadata": {
+            "type": "object",
+            "properties": {
+                "slots_per_epoch": {
+                    "type": "integer"
                 }
             }
         },
@@ -3713,6 +3760,55 @@
                 },
                 "status": {
                     "type": "string"
+                }
+            }
+        },
+        "api.APINetworkParticipation": {
+            "type": "object",
+            "properties": {
+                "complete": {
+                    "type": "boolean"
+                },
+                "expected_slots": {
+                    "type": "integer"
+                },
+                "indexed_slots": {
+                    "type": "integer"
+                },
+                "rate": {
+                    "type": "number"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "warning": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.APINetworkRawAggregates": {
+            "type": "object",
+            "properties": {
+                "attestations_indexed": {
+                    "type": "integer"
+                },
+                "complete": {
+                    "type": "boolean"
+                },
+                "expected_slots": {
+                    "type": "integer"
+                },
+                "globalparticipationrate": {
+                    "type": "number"
+                },
+                "indexed_slots": {
+                    "type": "integer"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "vote_participation": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -927,7 +927,7 @@
         },
         "/v1/network/overview": {
             "get": {
-                "description": "Returns the existing network overview data plus a safe health snapshot with current head slot, finality, validator counts, metadata, and provenance-aware aggregate data when available.",
+                "description": "Returns comprehensive network state information including network info, current state, checkpoints, validator stats, queue stats, fork information and a health snapshot with finality status, validator counts and provenance-aware participation data",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -845,22 +845,55 @@ definitions:
     type: object
   api.APINetworkOverviewData:
     properties:
+      active_validator_count:
+        type: integer
       checkpoints:
         $ref: '#/definitions/api.APICheckpoints'
+      current_epoch:
+        type: integer
+      current_slot:
+        type: integer
       current_state:
         $ref: '#/definitions/api.APICurrentState'
+      data_quality_warnings:
+        items:
+          type: string
+        type: array
+      epochs_since_finality:
+        type: integer
+      exited_validator_count:
+        type: integer
+      finalized_epoch:
+        type: integer
+      finalizing:
+        type: boolean
       forks:
         items:
           $ref: '#/definitions/api.APINetworkForkInfo'
         type: array
       is_synced:
         type: boolean
+      metadata:
+        $ref: '#/definitions/api.APINetworkOverviewMetadata'
       network_info:
         $ref: '#/definitions/api.APINetworkInfo'
+      participation:
+        $ref: '#/definitions/api.APINetworkParticipation'
+      pending_validator_count:
+        type: integer
       queue_stats:
         $ref: '#/definitions/api.APIQueueStats'
+      raw_aggregates:
+        $ref: '#/definitions/api.APINetworkRawAggregates'
+      total_validator_count:
+        type: integer
       validator_stats:
         $ref: '#/definitions/api.APIValidatorStats'
+    type: object
+  api.APINetworkOverviewMetadata:
+    properties:
+      slots_per_epoch:
+        type: integer
     type: object
   api.APINetworkOverviewResponse:
     properties:
@@ -868,6 +901,38 @@ definitions:
         $ref: '#/definitions/api.APINetworkOverviewData'
       status:
         type: string
+    type: object
+  api.APINetworkParticipation:
+    properties:
+      complete:
+        type: boolean
+      expected_slots:
+        type: integer
+      indexed_slots:
+        type: integer
+      rate:
+        type: number
+      source:
+        type: string
+      warning:
+        type: string
+    type: object
+  api.APINetworkRawAggregates:
+    properties:
+      attestations_indexed:
+        type: integer
+      complete:
+        type: boolean
+      expected_slots:
+        type: integer
+      globalparticipationrate:
+        type: number
+      indexed_slots:
+        type: integer
+      source:
+        type: string
+      vote_participation:
+        type: number
     type: object
   api.APINetworkSplitInfo:
     properties:
@@ -2463,8 +2528,9 @@ paths:
     get:
       consumes:
       - application/json
-      description: Returns comprehensive network state information including network
-        info, current state, checkpoints, validator stats, queue stats, and fork information
+      description: Returns the existing network overview data plus a safe health snapshot
+        with current head slot, finality, validator counts, metadata, and provenance-aware
+        aggregate data when available.
       operationId: getNetworkOverview
       produces:
       - application/json
@@ -2474,11 +2540,9 @@ paths:
           schema:
             $ref: '#/definitions/api.APINetworkOverviewResponse'
         "500":
-          description: Internal server error
+          description: Server Error
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/api.ApiResponse'
       summary: Get network overview
       tags:
       - network

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2528,9 +2528,10 @@ paths:
     get:
       consumes:
       - application/json
-      description: Returns the existing network overview data plus a safe health snapshot
-        with current head slot, finality, validator counts, metadata, and provenance-aware
-        aggregate data when available.
+      description: Returns comprehensive network state information including network
+        info, current state, checkpoints, validator stats, queue stats, fork information
+        and a health snapshot with finality status, validator counts and provenance-aware
+        participation data
       operationId: getNetworkOverview
       produces:
       - application/json

--- a/handlers/api/network_overview_v1.go
+++ b/handlers/api/network_overview_v1.go
@@ -27,13 +27,13 @@ const (
 	networkOverviewParticipationWarnText = "attestation index incomplete; participation omitted"
 )
 
-// APINetworkOverviewResponse represents the response structure for network overview.
+// APINetworkOverviewResponse represents the response structure for network overview
 type APINetworkOverviewResponse struct {
 	Status string                  `json:"status"`
 	Data   *APINetworkOverviewData `json:"data,omitempty"`
 }
 
-// APINetworkOverviewData contains one coherent network health snapshot.
+// APINetworkOverviewData contains comprehensive network state information
 type APINetworkOverviewData struct {
 	NetworkInfo           *APINetworkInfo            `json:"network_info"`
 	CurrentState          *APICurrentState           `json:"current_state"`
@@ -57,7 +57,7 @@ type APINetworkOverviewData struct {
 	Metadata              APINetworkOverviewMetadata `json:"metadata"`
 }
 
-// APINetworkInfo contains basic network information.
+// APINetworkInfo contains basic network information
 type APINetworkInfo struct {
 	NetworkName           string `json:"network_name"`
 	ConfigName            string `json:"config_name"`
@@ -69,7 +69,7 @@ type APINetworkInfo struct {
 	GenesisValidatorsRoot string `json:"genesis_validators_root"`
 }
 
-// APICurrentState contains current network state.
+// APICurrentState contains current network state
 type APICurrentState struct {
 	CurrentSlot          uint64  `json:"current_slot"`
 	CurrentEpoch         uint64  `json:"current_epoch"`
@@ -79,7 +79,7 @@ type APICurrentState struct {
 	EpochDurationMs      uint64  `json:"epoch_duration_ms"`
 }
 
-// APICheckpoints contains finalization and justification information.
+// APICheckpoints contains finalization and justification information
 type APICheckpoints struct {
 	FinalizedEpoch int64  `json:"finalized_epoch"`
 	FinalizedRoot  string `json:"finalized_root,omitempty"`
@@ -87,7 +87,7 @@ type APICheckpoints struct {
 	JustifiedRoot  string `json:"justified_root,omitempty"`
 }
 
-// APIValidatorStats contains validator statistics.
+// APIValidatorStats contains validator statistics
 type APIValidatorStats struct {
 	TotalBalance         uint64 `json:"total_balance"`
 	TotalActiveBalance   uint64 `json:"total_active_balance"`
@@ -96,7 +96,7 @@ type APIValidatorStats struct {
 	TotalEligibleEther   uint64 `json:"total_eligible_ether"`
 }
 
-// APIQueueStats contains queue statistics (Electra era).
+// APIQueueStats contains queue statistics (Electra era)
 type APIQueueStats struct {
 	EnteringValidatorCount        uint64 `json:"entering_validator_count"`
 	ExitingValidatorCount         uint64 `json:"exiting_validator_count"`
@@ -106,10 +106,12 @@ type APIQueueStats struct {
 	ExitEstimatedTimeToProcess    uint64 `json:"exit_estimated_time"`
 }
 
+// APINetworkOverviewMetadata contains metadata for interpreting the overview values
 type APINetworkOverviewMetadata struct {
 	SlotsPerEpoch uint64 `json:"slots_per_epoch"`
 }
 
+// APINetworkParticipation contains provenance-aware participation data
 type APINetworkParticipation struct {
 	Rate          *float64 `json:"rate"`
 	Source        string   `json:"source"`
@@ -119,6 +121,7 @@ type APINetworkParticipation struct {
 	Warning       string   `json:"warning,omitempty"`
 }
 
+// APINetworkRawAggregates contains raw aggregate values from the epoch vote index
 type APINetworkRawAggregates struct {
 	GlobalParticipationRate float64 `json:"globalparticipationrate"`
 	VoteParticipation       float64 `json:"vote_participation"`
@@ -127,14 +130,6 @@ type APINetworkRawAggregates struct {
 	ExpectedSlots           uint64  `json:"expected_slots"`
 	Source                  string  `json:"source"`
 	Complete                bool    `json:"complete"`
-}
-
-type networkOverviewInput struct {
-	CurrentSlot       uint64
-	SlotsPerEpoch     uint64
-	FinalizedEpoch    uint64
-	ValidatorStatuses map[v1.ValidatorState]uint64
-	RawAggregate      *networkOverviewRawAggregate
 }
 
 type networkOverviewRawAggregate struct {
@@ -146,9 +141,9 @@ type networkOverviewRawAggregate struct {
 	Complete                bool
 }
 
-// APINetworkOverviewV1 returns a safe network health overview.
+// APINetworkOverviewV1 returns comprehensive network state overview
 // @Summary Get network overview
-// @Description Returns the existing network overview data plus a safe health snapshot with current head slot, finality, validator counts, metadata, and provenance-aware aggregate data when available.
+// @Description Returns comprehensive network state information including network info, current state, checkpoints, validator stats, queue stats, fork information and a health snapshot with finality status, validator counts and provenance-aware participation data
 // @Tags network
 // @Accept json
 // @Produce json
@@ -159,27 +154,24 @@ type networkOverviewRawAggregate struct {
 func APINetworkOverviewV1(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
+	// Use caching layer for this endpoint since it has no filters
 	var pageData *APINetworkOverviewData
-	if services.GlobalFrontendCache == nil {
-		pageData, _ = buildNetworkOverviewData(r.Context())
-	} else {
-		pageCacheKey := "api_network_overview"
-		pageRes, pageErr := services.GlobalFrontendCache.ProcessCachedPage(pageCacheKey, true, pageData, func(pageCall *services.FrontendCacheProcessingPage) interface{} {
-			data, cacheTimeout := buildNetworkOverviewData(pageCall.CallCtx)
-			pageCall.CacheTimeout = cacheTimeout
-			return data
-		})
+	pageCacheKey := "api_network_overview"
+	pageRes, pageErr := services.GlobalFrontendCache.ProcessCachedPage(pageCacheKey, true, pageData, func(pageCall *services.FrontendCacheProcessingPage) interface{} {
+		data, cacheTimeout := buildNetworkOverviewData(pageCall.CallCtx)
+		pageCall.CacheTimeout = cacheTimeout
+		return data
+	})
 
-		if pageErr != nil {
-			logrus.WithError(pageErr).Error("failed to process network overview page")
-			sendServerErrorResponse(w, r.URL.String(), "failed to process network overview")
-			return
-		}
+	if pageErr != nil {
+		logrus.WithError(pageErr).Error("failed to process network overview page")
+		sendServerErrorResponse(w, r.URL.String(), "failed to process network overview")
+		return
+	}
 
-		if pageRes != nil {
-			if resData, ok := pageRes.(*APINetworkOverviewData); ok {
-				pageData = resData
-			}
+	if pageRes != nil {
+		if resData, ok := pageRes.(*APINetworkOverviewData); ok {
+			pageData = resData
 		}
 	}
 
@@ -201,61 +193,37 @@ func APINetworkOverviewV1(w http.ResponseWriter, r *http.Request) {
 }
 
 func buildNetworkOverviewData(ctx context.Context) (*APINetworkOverviewData, time.Duration) {
-	if services.GlobalBeaconService == nil {
-		return nil, time.Minute
-	}
-
 	chainState := services.GlobalBeaconService.GetChainState()
-	if chainState == nil {
-		return nil, time.Minute
-	}
-
 	specs := chainState.GetSpecs()
-	if specs == nil || specs.SlotsPerEpoch == 0 {
-		return nil, time.Minute
-	}
-
 	currentEpoch := chainState.CurrentEpoch()
 	currentSlot := chainState.CurrentSlot()
 	currentSlotIndex := chainState.SlotToSlotIndex(currentSlot) + 1
+	networkGenesis := chainState.GetGenesis()
 
-	beaconIndexer := services.GlobalBeaconService.GetBeaconIndexer()
-	if beaconIndexer == nil {
-		return nil, time.Duration(specs.SlotDurationMs) * time.Millisecond
+	if specs == nil {
+		return nil, time.Minute
 	}
 
-	canonicalHead := beaconIndexer.GetCanonicalHead(nil)
-	if canonicalHead == nil {
-		return nil, time.Duration(specs.SlotDurationMs) * time.Millisecond
-	}
-
-	headEpoch := chainState.EpochOfSlot(canonicalHead.Slot)
 	finalizedEpoch, finalizedRoot := chainState.GetFinalizedCheckpoint()
 	justifiedEpoch, justifiedRoot := chainState.GetJustifiedCheckpoint()
-	rawAggregate := getNetworkOverviewRawAggregate(ctx, uint64(headEpoch), specs.SlotsPerEpoch)
 
-	data := buildSafeNetworkOverview(networkOverviewInput{
-		CurrentSlot:       uint64(canonicalHead.Slot),
-		SlotsPerEpoch:     specs.SlotsPerEpoch,
-		FinalizedEpoch:    uint64(finalizedEpoch),
-		ValidatorStatuses: beaconIndexer.GetValidatorStatusMap(headEpoch, canonicalHead.Root),
-		RawAggregate:      rawAggregate,
-	})
-
+	// Check sync state
 	syncState := dbtypes.IndexerSyncState{}
 	db.GetExplorerState(ctx, "indexer.syncstate", &syncState)
+	var isSynced bool
 	if finalizedEpoch >= 1 {
-		data.IsSynced = syncState.Epoch >= uint64(finalizedEpoch-1)
+		isSynced = syncState.Epoch >= uint64(finalizedEpoch-1)
 	} else {
-		data.IsSynced = true
+		isSynced = true
 	}
 
+	// Network info
 	networkName := specs.ConfigName
 	if utils.Config.Chain.DisplayName != "" {
 		networkName = utils.Config.Chain.DisplayName
 	}
 
-	data.NetworkInfo = &APINetworkInfo{
+	networkInfo := &APINetworkInfo{
 		NetworkName:           networkName,
 		ConfigName:            specs.ConfigName,
 		DepositContract:       common.Address(specs.DepositContractAddress).String(),
@@ -263,13 +231,14 @@ func buildNetworkOverviewData(ctx context.Context) (*APINetworkOverviewData, tim
 		ConsolidationContract: services.GlobalBeaconService.GetSystemContractAddress(rpc.ConsolidationRequestContract).String(),
 	}
 
-	if networkGenesis := chainState.GetGenesis(); networkGenesis != nil {
-		data.NetworkInfo.GenesisTime = networkGenesis.GenesisTime.Unix()
-		data.NetworkInfo.GenesisRoot = fmt.Sprintf("0x%x", networkGenesis.GenesisValidatorsRoot)
-		data.NetworkInfo.GenesisValidatorsRoot = fmt.Sprintf("0x%x", networkGenesis.GenesisValidatorsRoot)
+	if networkGenesis != nil {
+		networkInfo.GenesisTime = networkGenesis.GenesisTime.Unix()
+		networkInfo.GenesisRoot = fmt.Sprintf("0x%x", networkGenesis.GenesisValidatorsRoot)
+		networkInfo.GenesisValidatorsRoot = fmt.Sprintf("0x%x", networkGenesis.GenesisValidatorsRoot)
 	}
 
-	data.CurrentState = &APICurrentState{
+	// Current state
+	currentState := &APICurrentState{
 		CurrentSlot:          uint64(currentSlot),
 		CurrentEpoch:         uint64(currentEpoch),
 		CurrentEpochProgress: float64(100) * float64(currentSlotIndex) / float64(specs.SlotsPerEpoch),
@@ -278,38 +247,43 @@ func buildNetworkOverviewData(ctx context.Context) (*APINetworkOverviewData, tim
 		EpochDurationMs:      specs.SlotDurationMs * specs.SlotsPerEpoch,
 	}
 
-	data.Checkpoints = &APICheckpoints{
+	// Checkpoints
+	checkpoints := &APICheckpoints{
 		FinalizedEpoch: int64(finalizedEpoch),
 		JustifiedEpoch: int64(justifiedEpoch),
 	}
 	if finalizedRoot != consensus.NullRoot {
-		data.Checkpoints.FinalizedRoot = fmt.Sprintf("0x%x", finalizedRoot)
+		checkpoints.FinalizedRoot = fmt.Sprintf("0x%x", finalizedRoot)
 	}
 	if justifiedRoot != consensus.NullRoot {
-		data.Checkpoints.JustifiedRoot = fmt.Sprintf("0x%x", justifiedRoot)
+		checkpoints.JustifiedRoot = fmt.Sprintf("0x%x", justifiedRoot)
 	}
 
-	data.ValidatorStats = &APIValidatorStats{}
+	// Validator stats
+	validatorStats := &APIValidatorStats{}
 	recentEpochStatsValues, _ := services.GlobalBeaconService.GetRecentEpochStats(nil)
 	if recentEpochStatsValues != nil {
-		data.ValidatorStats.ActiveValidatorCount = recentEpochStatsValues.ActiveValidators
-		data.ValidatorStats.TotalActiveBalance = uint64(recentEpochStatsValues.ActiveBalance)
-		data.ValidatorStats.TotalEligibleEther = uint64(recentEpochStatsValues.EffectiveBalance)
+		validatorStats.ActiveValidatorCount = recentEpochStatsValues.ActiveValidators
+		validatorStats.TotalActiveBalance = uint64(recentEpochStatsValues.ActiveBalance)
+		validatorStats.TotalEligibleEther = uint64(recentEpochStatsValues.EffectiveBalance)
 		if recentEpochStatsValues.ActiveValidators > 0 {
-			data.ValidatorStats.AverageBalance = uint64(recentEpochStatsValues.ActiveBalance) / recentEpochStatsValues.ActiveValidators
+			validatorStats.AverageBalance = uint64(recentEpochStatsValues.ActiveBalance) / recentEpochStatsValues.ActiveValidators
 		}
-		data.ValidatorStats.TotalBalance = uint64(recentEpochStatsValues.TotalBalance)
+		validatorStats.TotalBalance = uint64(recentEpochStatsValues.TotalBalance)
 	}
 
+	// Queue stats (only for Electra era)
+	var queueStats *APIQueueStats
 	if specs.ElectraForkEpoch != nil && *specs.ElectraForkEpoch <= uint64(currentEpoch) {
-		activationQueueLength, exitQueueLength := beaconIndexer.GetActivationExitQueueLengths(currentEpoch, nil)
+		activationQueueLength, exitQueueLength := services.GlobalBeaconService.GetBeaconIndexer().GetActivationExitQueueLengths(currentEpoch, nil)
 
-		data.QueueStats = &APIQueueStats{
+		queueStats = &APIQueueStats{
 			EnteringValidatorCount: activationQueueLength,
 			ExitingValidatorCount:  exitQueueLength,
 		}
 
-		depositQueue := beaconIndexer.GetLatestDepositQueue(nil)
+		// Electra deposit queue
+		depositQueue := services.GlobalBeaconService.GetBeaconIndexer().GetLatestDepositQueue(nil)
 		if depositQueue != nil {
 			depositAmount := phase0.Gwei(0)
 			validatorCount := uint64(0)
@@ -327,86 +301,99 @@ func buildNetworkOverviewData(ctx context.Context) (*APINetworkOverviewData, tim
 				}
 			}
 
-			data.QueueStats.EnteringValidatorCount += validatorCount
-			data.QueueStats.EnteringEtherAmount = uint64(depositAmount)
+			queueStats.EnteringValidatorCount += validatorCount
+			queueStats.EnteringEtherAmount = uint64(depositAmount)
 
-			if data.ValidatorStats.TotalEligibleEther > 0 {
-				etherChurnPerEpoch := chainState.GetActivationExitChurnLimit(data.ValidatorStats.TotalEligibleEther)
-				data.QueueStats.EtherChurnPerDay = etherChurnPerEpoch * 225 // ~225 epochs per day
+			if validatorStats.TotalEligibleEther > 0 {
+				etherChurnPerEpoch := chainState.GetActivationExitChurnLimit(validatorStats.TotalEligibleEther)
+				queueStats.EtherChurnPerDay = etherChurnPerEpoch * 225 // ~225 epochs per day
 
-				if data.QueueStats.EtherChurnPerDay > 0 {
-					depositDays := float64(depositAmount) / float64(data.QueueStats.EtherChurnPerDay)
-					data.QueueStats.DepositEstimatedTimeToProcess = uint64(depositDays * 24 * 60 * 60)
+				if queueStats.EtherChurnPerDay > 0 {
+					// Calculate deposit time in seconds
+					depositDays := float64(depositAmount) / float64(queueStats.EtherChurnPerDay)
+					queueStats.DepositEstimatedTimeToProcess = uint64(depositDays * 24 * 60 * 60)
 
-					exitEtherAmount := data.QueueStats.ExitingValidatorCount * data.ValidatorStats.AverageBalance
-					exitDays := float64(exitEtherAmount) / float64(data.QueueStats.EtherChurnPerDay)
-					data.QueueStats.ExitEstimatedTimeToProcess = uint64(exitDays * 24 * 60 * 60)
+					// Calculate exit time in seconds
+					// Assuming each validator has the average balance
+					exitEtherAmount := queueStats.ExitingValidatorCount * validatorStats.AverageBalance
+					exitDays := float64(exitEtherAmount) / float64(queueStats.EtherChurnPerDay)
+					queueStats.ExitEstimatedTimeToProcess = uint64(exitDays * 24 * 60 * 60)
 				}
 			}
 		}
 	}
 
-	data.Forks = buildNetworkForks(chainState)
+	// Fork information (reuse from network forks API)
+	forks := buildNetworkForks(chainState)
 
-	cacheTimeout := time.Duration(specs.SlotDurationMs) * time.Millisecond
-	return data, cacheTimeout
-}
-
-func buildSafeNetworkOverview(input networkOverviewInput) *APINetworkOverviewData {
-	currentEpoch := uint64(0)
-	if input.SlotsPerEpoch > 0 {
-		currentEpoch = input.CurrentSlot / input.SlotsPerEpoch
+	// Health snapshot based on the indexer's canonical head (may lag behind wall clock)
+	headSlot := currentSlot
+	if canonicalHead := services.GlobalBeaconService.GetBeaconIndexer().GetCanonicalHead(nil); canonicalHead != nil {
+		headSlot = canonicalHead.Slot
 	}
+	headEpoch := chainState.EpochOfSlot(headSlot)
 
 	warnings := []string{}
 	epochsSinceFinality := uint64(0)
-	if currentEpoch >= input.FinalizedEpoch {
-		epochsSinceFinality = currentEpoch - input.FinalizedEpoch
+	if headEpoch >= finalizedEpoch {
+		epochsSinceFinality = uint64(headEpoch - finalizedEpoch)
 	} else {
-		warnings = append(warnings, fmt.Sprintf("finalized_epoch %d is ahead of current_epoch %d", input.FinalizedEpoch, currentEpoch))
+		warnings = append(warnings, fmt.Sprintf("finalized_epoch %d is ahead of current_epoch %d", finalizedEpoch, headEpoch))
+	}
+	finalizing := epochsSinceFinality <= networkOverviewFinalizingThreshold
+
+	activeCount, pendingCount, exitedCount, totalCount := summarizeValidatorStatuses(services.GlobalBeaconService.GetValidatorStatusMap())
+
+	// Participation from the epoch vote index, with provenance & completeness info
+	var participation *APINetworkParticipation
+	var rawAggregates *APINetworkRawAggregates
+	if dbEpochs := services.GlobalBeaconService.GetDbEpochs(ctx, uint64(headEpoch), 1); len(dbEpochs) > 0 {
+		if rawAggregate := buildNetworkOverviewRawAggregate(dbEpochs[0], specs.SlotsPerEpoch); rawAggregate != nil {
+			rawAggregates = &APINetworkRawAggregates{
+				GlobalParticipationRate: rawAggregate.GlobalParticipationRate,
+				VoteParticipation:       rawAggregate.VoteParticipation,
+				AttestationsIndexed:     rawAggregate.AttestationsIndexed,
+				IndexedSlots:            rawAggregate.IndexedSlots,
+				ExpectedSlots:           rawAggregate.ExpectedSlots,
+				Source:                  networkOverviewRawAggregateSource,
+				Complete:                rawAggregate.Complete,
+			}
+
+			var participationWarning string
+			participation, participationWarning = buildNetworkOverviewParticipation(rawAggregate, finalizing, epochsSinceFinality)
+			if participationWarning != "" {
+				warnings = append(warnings, participationWarning)
+			}
+		}
 	}
 
-	activeValidatorCount, pendingValidatorCount, exitedValidatorCount, totalValidatorCount := summarizeValidatorStatuses(input.ValidatorStatuses)
 	data := &APINetworkOverviewData{
-		CurrentSlot:           input.CurrentSlot,
-		CurrentEpoch:          currentEpoch,
-		FinalizedEpoch:        input.FinalizedEpoch,
+		NetworkInfo:           networkInfo,
+		CurrentState:          currentState,
+		Checkpoints:           checkpoints,
+		ValidatorStats:        validatorStats,
+		QueueStats:            queueStats,
+		Forks:                 forks,
+		IsSynced:              isSynced,
+		CurrentSlot:           uint64(headSlot),
+		CurrentEpoch:          uint64(headEpoch),
+		FinalizedEpoch:        uint64(finalizedEpoch),
 		EpochsSinceFinality:   epochsSinceFinality,
-		Finalizing:            epochsSinceFinality <= networkOverviewFinalizingThreshold,
-		ActiveValidatorCount:  activeValidatorCount,
-		TotalValidatorCount:   totalValidatorCount,
-		PendingValidatorCount: pendingValidatorCount,
-		ExitedValidatorCount:  exitedValidatorCount,
+		Finalizing:            finalizing,
+		ActiveValidatorCount:  activeCount,
+		TotalValidatorCount:   totalCount,
+		PendingValidatorCount: pendingCount,
+		ExitedValidatorCount:  exitedCount,
 		DataQualityWarnings:   warnings,
+		Participation:         participation,
+		RawAggregates:         rawAggregates,
 		Metadata: APINetworkOverviewMetadata{
-			SlotsPerEpoch: input.SlotsPerEpoch,
+			SlotsPerEpoch: specs.SlotsPerEpoch,
 		},
 	}
 
-	if input.RawAggregate != nil {
-		data.RawAggregates = &APINetworkRawAggregates{
-			GlobalParticipationRate: input.RawAggregate.GlobalParticipationRate,
-			VoteParticipation:       input.RawAggregate.VoteParticipation,
-			AttestationsIndexed:     input.RawAggregate.AttestationsIndexed,
-			IndexedSlots:            input.RawAggregate.IndexedSlots,
-			ExpectedSlots:           input.RawAggregate.ExpectedSlots,
-			Source:                  networkOverviewRawAggregateSource,
-			Complete:                input.RawAggregate.Complete,
-		}
-
-		var participationWarning string
-		if data.Finalizing && input.RawAggregate.GlobalParticipationRate < networkOverviewParticipationQuorum {
-			participationWarning = fmt.Sprintf(
-				"vote participation aggregate reports %.1f%% while finalized_epoch is only %d epochs behind current_epoch; aggregate is likely incomplete",
-				input.RawAggregate.GlobalParticipationRate,
-				data.EpochsSinceFinality,
-			)
-			data.DataQualityWarnings = append(data.DataQualityWarnings, participationWarning)
-		}
-		data.Participation = buildNetworkOverviewParticipation(input.RawAggregate, participationWarning)
-	}
-
-	return data
+	cacheTimeout := time.Duration(specs.SlotDurationMs) * time.Millisecond
+	return data, cacheTimeout
 }
 
 func summarizeValidatorStatuses(statuses map[v1.ValidatorState]uint64) (active uint64, pending uint64, exited uint64, total uint64) {
@@ -426,43 +413,36 @@ func summarizeValidatorStatuses(statuses map[v1.ValidatorState]uint64) (active u
 	return active, pending, exited, total
 }
 
-func buildNetworkOverviewParticipation(raw *networkOverviewRawAggregate, warning string) *APINetworkParticipation {
-	if raw == nil {
-		return nil
+// buildNetworkOverviewParticipation derives the participation info from the raw vote aggregate.
+// The rate is only exposed when the aggregate is complete and doesn't contradict the finality state;
+// otherwise a warning explaining the omission is returned alongside.
+func buildNetworkOverviewParticipation(raw *networkOverviewRawAggregate, finalizing bool, epochsSinceFinality uint64) (*APINetworkParticipation, string) {
+	var warning string
+	if finalizing && raw.GlobalParticipationRate < networkOverviewParticipationQuorum {
+		warning = fmt.Sprintf(
+			"vote participation aggregate reports %.1f%% while finalized_epoch is only %d epochs behind current_epoch; aggregate is likely incomplete",
+			raw.GlobalParticipationRate,
+			epochsSinceFinality,
+		)
 	}
 
 	participation := &APINetworkParticipation{
-		Rate:          nil,
 		Source:        networkOverviewParticipationSource,
 		Complete:      raw.Complete && warning == "",
 		IndexedSlots:  raw.IndexedSlots,
 		ExpectedSlots: raw.ExpectedSlots,
 	}
 
-	if raw.Complete && warning == "" {
+	if participation.Complete {
 		rate := raw.GlobalParticipationRate
 		participation.Rate = &rate
+	} else if warning != "" {
+		participation.Warning = warning
 	} else {
 		participation.Warning = networkOverviewParticipationWarnText
-		if warning != "" {
-			participation.Warning = warning
-		}
 	}
 
-	return participation
-}
-
-func getNetworkOverviewRawAggregate(ctx context.Context, epoch uint64, slotsPerEpoch uint64) *networkOverviewRawAggregate {
-	if slotsPerEpoch == 0 {
-		return nil
-	}
-
-	dbEpochs := services.GlobalBeaconService.GetDbEpochs(ctx, epoch, 1)
-	if len(dbEpochs) == 0 || dbEpochs[0] == nil {
-		return nil
-	}
-
-	return buildNetworkOverviewRawAggregate(dbEpochs[0], slotsPerEpoch)
+	return participation, warning
 }
 
 func buildNetworkOverviewRawAggregate(dbEpoch *dbtypes.Epoch, slotsPerEpoch uint64) *networkOverviewRawAggregate {
@@ -470,13 +450,11 @@ func buildNetworkOverviewRawAggregate(dbEpoch *dbtypes.Epoch, slotsPerEpoch uint
 		return nil
 	}
 
-	globalParticipationRate := float64(dbEpoch.VotedTarget) * 100 / float64(dbEpoch.Eligible)
-	voteParticipation := float64(dbEpoch.VotedTotal) * 100 / float64(dbEpoch.Eligible)
 	indexedSlots := uint64(dbEpoch.BlockCount)
 
 	return &networkOverviewRawAggregate{
-		GlobalParticipationRate: globalParticipationRate,
-		VoteParticipation:       voteParticipation,
+		GlobalParticipationRate: float64(dbEpoch.VotedTarget) * 100 / float64(dbEpoch.Eligible),
+		VoteParticipation:       float64(dbEpoch.VotedTotal) * 100 / float64(dbEpoch.Eligible),
 		AttestationsIndexed:     dbEpoch.AttestationCount,
 		IndexedSlots:            indexedSlots,
 		ExpectedSlots:           slotsPerEpoch,

--- a/handlers/api/network_overview_v1.go
+++ b/handlers/api/network_overview_v1.go
@@ -14,28 +14,50 @@ import (
 	"github.com/ethpandaops/dora/dbtypes"
 	"github.com/ethpandaops/dora/services"
 	"github.com/ethpandaops/dora/utils"
+	v1 "github.com/ethpandaops/go-eth2-client/api/v1"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/sirupsen/logrus"
 )
 
-// APINetworkOverviewResponse represents the response structure for network overview
+const (
+	networkOverviewFinalizingThreshold   = uint64(2)
+	networkOverviewParticipationQuorum   = 67.0
+	networkOverviewParticipationSource   = "attestation_index"
+	networkOverviewRawAggregateSource    = "epoch_vote_index"
+	networkOverviewParticipationWarnText = "attestation index incomplete; participation omitted"
+)
+
+// APINetworkOverviewResponse represents the response structure for network overview.
 type APINetworkOverviewResponse struct {
 	Status string                  `json:"status"`
-	Data   *APINetworkOverviewData `json:"data"`
+	Data   *APINetworkOverviewData `json:"data,omitempty"`
 }
 
-// APINetworkOverviewData contains comprehensive network state information
+// APINetworkOverviewData contains one coherent network health snapshot.
 type APINetworkOverviewData struct {
-	NetworkInfo    *APINetworkInfo       `json:"network_info"`
-	CurrentState   *APICurrentState      `json:"current_state"`
-	Checkpoints    *APICheckpoints       `json:"checkpoints"`
-	ValidatorStats *APIValidatorStats    `json:"validator_stats"`
-	QueueStats     *APIQueueStats        `json:"queue_stats,omitempty"`
-	Forks          []*APINetworkForkInfo `json:"forks"`
-	IsSynced       bool                  `json:"is_synced"`
+	NetworkInfo           *APINetworkInfo            `json:"network_info"`
+	CurrentState          *APICurrentState           `json:"current_state"`
+	Checkpoints           *APICheckpoints            `json:"checkpoints"`
+	ValidatorStats        *APIValidatorStats         `json:"validator_stats"`
+	QueueStats            *APIQueueStats             `json:"queue_stats,omitempty"`
+	Forks                 []*APINetworkForkInfo      `json:"forks"`
+	IsSynced              bool                       `json:"is_synced"`
+	CurrentSlot           uint64                     `json:"current_slot"`
+	CurrentEpoch          uint64                     `json:"current_epoch"`
+	FinalizedEpoch        uint64                     `json:"finalized_epoch"`
+	EpochsSinceFinality   uint64                     `json:"epochs_since_finality"`
+	Finalizing            bool                       `json:"finalizing"`
+	ActiveValidatorCount  uint64                     `json:"active_validator_count"`
+	TotalValidatorCount   uint64                     `json:"total_validator_count"`
+	PendingValidatorCount uint64                     `json:"pending_validator_count"`
+	ExitedValidatorCount  uint64                     `json:"exited_validator_count"`
+	DataQualityWarnings   []string                   `json:"data_quality_warnings"`
+	Participation         *APINetworkParticipation   `json:"participation,omitempty"`
+	RawAggregates         *APINetworkRawAggregates   `json:"raw_aggregates,omitempty"`
+	Metadata              APINetworkOverviewMetadata `json:"metadata"`
 }
 
-// APINetworkInfo contains basic network information
+// APINetworkInfo contains basic network information.
 type APINetworkInfo struct {
 	NetworkName           string `json:"network_name"`
 	ConfigName            string `json:"config_name"`
@@ -47,7 +69,7 @@ type APINetworkInfo struct {
 	GenesisValidatorsRoot string `json:"genesis_validators_root"`
 }
 
-// APICurrentState contains current network state
+// APICurrentState contains current network state.
 type APICurrentState struct {
 	CurrentSlot          uint64  `json:"current_slot"`
 	CurrentEpoch         uint64  `json:"current_epoch"`
@@ -57,7 +79,7 @@ type APICurrentState struct {
 	EpochDurationMs      uint64  `json:"epoch_duration_ms"`
 }
 
-// APICheckpoints contains finalization and justification information
+// APICheckpoints contains finalization and justification information.
 type APICheckpoints struct {
 	FinalizedEpoch int64  `json:"finalized_epoch"`
 	FinalizedRoot  string `json:"finalized_root,omitempty"`
@@ -65,7 +87,7 @@ type APICheckpoints struct {
 	JustifiedRoot  string `json:"justified_root,omitempty"`
 }
 
-// APIValidatorStats contains validator statistics
+// APIValidatorStats contains validator statistics.
 type APIValidatorStats struct {
 	TotalBalance         uint64 `json:"total_balance"`
 	TotalActiveBalance   uint64 `json:"total_active_balance"`
@@ -74,7 +96,7 @@ type APIValidatorStats struct {
 	TotalEligibleEther   uint64 `json:"total_eligible_ether"`
 }
 
-// APIQueueStats contains queue statistics (Electra era)
+// APIQueueStats contains queue statistics (Electra era).
 type APIQueueStats struct {
 	EnteringValidatorCount        uint64 `json:"entering_validator_count"`
 	ExitingValidatorCount         uint64 `json:"exiting_validator_count"`
@@ -84,42 +106,85 @@ type APIQueueStats struct {
 	ExitEstimatedTimeToProcess    uint64 `json:"exit_estimated_time"`
 }
 
-// APINetworkOverviewV1 returns comprehensive network state overview
+type APINetworkOverviewMetadata struct {
+	SlotsPerEpoch uint64 `json:"slots_per_epoch"`
+}
+
+type APINetworkParticipation struct {
+	Rate          *float64 `json:"rate"`
+	Source        string   `json:"source"`
+	Complete      bool     `json:"complete"`
+	IndexedSlots  uint64   `json:"indexed_slots"`
+	ExpectedSlots uint64   `json:"expected_slots"`
+	Warning       string   `json:"warning,omitempty"`
+}
+
+type APINetworkRawAggregates struct {
+	GlobalParticipationRate float64 `json:"globalparticipationrate"`
+	VoteParticipation       float64 `json:"vote_participation"`
+	AttestationsIndexed     uint64  `json:"attestations_indexed"`
+	IndexedSlots            uint64  `json:"indexed_slots"`
+	ExpectedSlots           uint64  `json:"expected_slots"`
+	Source                  string  `json:"source"`
+	Complete                bool    `json:"complete"`
+}
+
+type networkOverviewInput struct {
+	CurrentSlot       uint64
+	SlotsPerEpoch     uint64
+	FinalizedEpoch    uint64
+	ValidatorStatuses map[v1.ValidatorState]uint64
+	RawAggregate      *networkOverviewRawAggregate
+}
+
+type networkOverviewRawAggregate struct {
+	GlobalParticipationRate float64
+	VoteParticipation       float64
+	AttestationsIndexed     uint64
+	IndexedSlots            uint64
+	ExpectedSlots           uint64
+	Complete                bool
+}
+
+// APINetworkOverviewV1 returns a safe network health overview.
 // @Summary Get network overview
-// @Description Returns comprehensive network state information including network info, current state, checkpoints, validator stats, queue stats, and fork information
+// @Description Returns the existing network overview data plus a safe health snapshot with current head slot, finality, validator counts, metadata, and provenance-aware aggregate data when available.
 // @Tags network
 // @Accept json
 // @Produce json
 // @Success 200 {object} APINetworkOverviewResponse
-// @Failure 500 {object} map[string]string "Internal server error"
+// @Failure 500 {object} ApiResponse "Server Error"
 // @Router /v1/network/overview [get]
 // @ID getNetworkOverview
 func APINetworkOverviewV1(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	// Use caching layer for this endpoint since it has no filters
 	var pageData *APINetworkOverviewData
-	pageCacheKey := "api_network_overview"
-	pageRes, pageErr := services.GlobalFrontendCache.ProcessCachedPage(pageCacheKey, true, pageData, func(pageCall *services.FrontendCacheProcessingPage) interface{} {
-		data, cacheTimeout := buildNetworkOverviewData(pageCall.CallCtx)
-		pageCall.CacheTimeout = cacheTimeout
-		return data
-	})
+	if services.GlobalFrontendCache == nil {
+		pageData, _ = buildNetworkOverviewData(r.Context())
+	} else {
+		pageCacheKey := "api_network_overview"
+		pageRes, pageErr := services.GlobalFrontendCache.ProcessCachedPage(pageCacheKey, true, pageData, func(pageCall *services.FrontendCacheProcessingPage) interface{} {
+			data, cacheTimeout := buildNetworkOverviewData(pageCall.CallCtx)
+			pageCall.CacheTimeout = cacheTimeout
+			return data
+		})
 
-	if pageErr != nil {
-		logrus.WithError(pageErr).Error("failed to process network overview page")
-		http.Error(w, `{"status": "ERROR: failed to process network overview"}`, http.StatusInternalServerError)
-		return
-	}
+		if pageErr != nil {
+			logrus.WithError(pageErr).Error("failed to process network overview page")
+			sendServerErrorResponse(w, r.URL.String(), "failed to process network overview")
+			return
+		}
 
-	if pageRes != nil {
-		if resData, ok := pageRes.(*APINetworkOverviewData); ok {
-			pageData = resData
+		if pageRes != nil {
+			if resData, ok := pageRes.(*APINetworkOverviewData); ok {
+				pageData = resData
+			}
 		}
 	}
 
 	if pageData == nil {
-		http.Error(w, `{"status": "ERROR: failed to build network overview"}`, http.StatusInternalServerError)
+		sendServerErrorResponse(w, r.URL.String(), "failed to build network overview")
 		return
 	}
 
@@ -130,43 +195,67 @@ func APINetworkOverviewV1(w http.ResponseWriter, r *http.Request) {
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		logrus.WithError(err).Error("failed to encode network overview response")
-		http.Error(w, `{"status": "ERROR: failed to encode response"}`, http.StatusInternalServerError)
+		sendServerErrorResponse(w, r.URL.String(), "failed to encode response")
 		return
 	}
 }
 
 func buildNetworkOverviewData(ctx context.Context) (*APINetworkOverviewData, time.Duration) {
-	chainState := services.GlobalBeaconService.GetChainState()
-	specs := chainState.GetSpecs()
-	currentEpoch := chainState.CurrentEpoch()
-	currentSlot := chainState.CurrentSlot()
-	currentSlotIndex := chainState.SlotToSlotIndex(currentSlot) + 1
-	networkGenesis := chainState.GetGenesis()
-
-	if specs == nil {
+	if services.GlobalBeaconService == nil {
 		return nil, time.Minute
 	}
 
-	finalizedEpoch, finalizedRoot := chainState.GetFinalizedCheckpoint()
-	justifiedEpoch, justifiedRoot := chainState.GetJustifiedCheckpoint()
-
-	// Check sync state
-	syncState := dbtypes.IndexerSyncState{}
-	db.GetExplorerState(ctx, "indexer.syncstate", &syncState)
-	var isSynced bool
-	if finalizedEpoch >= 1 {
-		isSynced = syncState.Epoch >= uint64(finalizedEpoch-1)
-	} else {
-		isSynced = true
+	chainState := services.GlobalBeaconService.GetChainState()
+	if chainState == nil {
+		return nil, time.Minute
 	}
 
-	// Network info
+	specs := chainState.GetSpecs()
+	if specs == nil || specs.SlotsPerEpoch == 0 {
+		return nil, time.Minute
+	}
+
+	currentEpoch := chainState.CurrentEpoch()
+	currentSlot := chainState.CurrentSlot()
+	currentSlotIndex := chainState.SlotToSlotIndex(currentSlot) + 1
+
+	beaconIndexer := services.GlobalBeaconService.GetBeaconIndexer()
+	if beaconIndexer == nil {
+		return nil, time.Duration(specs.SlotDurationMs) * time.Millisecond
+	}
+
+	canonicalHead := beaconIndexer.GetCanonicalHead(nil)
+	if canonicalHead == nil {
+		return nil, time.Duration(specs.SlotDurationMs) * time.Millisecond
+	}
+
+	headEpoch := chainState.EpochOfSlot(canonicalHead.Slot)
+	finalizedEpoch, finalizedRoot := chainState.GetFinalizedCheckpoint()
+	justifiedEpoch, justifiedRoot := chainState.GetJustifiedCheckpoint()
+	rawAggregate := getNetworkOverviewRawAggregate(ctx, uint64(headEpoch), specs.SlotsPerEpoch)
+
+	data := buildSafeNetworkOverview(networkOverviewInput{
+		CurrentSlot:       uint64(canonicalHead.Slot),
+		SlotsPerEpoch:     specs.SlotsPerEpoch,
+		FinalizedEpoch:    uint64(finalizedEpoch),
+		ValidatorStatuses: beaconIndexer.GetValidatorStatusMap(headEpoch, canonicalHead.Root),
+		RawAggregate:      rawAggregate,
+	})
+
+	syncState := dbtypes.IndexerSyncState{}
+	db.GetExplorerState(ctx, "indexer.syncstate", &syncState)
+	if finalizedEpoch >= 1 {
+		data.IsSynced = syncState.Epoch >= uint64(finalizedEpoch-1)
+	} else {
+		data.IsSynced = true
+	}
+
 	networkName := specs.ConfigName
 	if utils.Config.Chain.DisplayName != "" {
 		networkName = utils.Config.Chain.DisplayName
 	}
 
-	networkInfo := &APINetworkInfo{
+	data.NetworkInfo = &APINetworkInfo{
 		NetworkName:           networkName,
 		ConfigName:            specs.ConfigName,
 		DepositContract:       common.Address(specs.DepositContractAddress).String(),
@@ -174,14 +263,13 @@ func buildNetworkOverviewData(ctx context.Context) (*APINetworkOverviewData, tim
 		ConsolidationContract: services.GlobalBeaconService.GetSystemContractAddress(rpc.ConsolidationRequestContract).String(),
 	}
 
-	if networkGenesis != nil {
-		networkInfo.GenesisTime = networkGenesis.GenesisTime.Unix()
-		networkInfo.GenesisRoot = fmt.Sprintf("0x%x", networkGenesis.GenesisValidatorsRoot)
-		networkInfo.GenesisValidatorsRoot = fmt.Sprintf("0x%x", networkGenesis.GenesisValidatorsRoot)
+	if networkGenesis := chainState.GetGenesis(); networkGenesis != nil {
+		data.NetworkInfo.GenesisTime = networkGenesis.GenesisTime.Unix()
+		data.NetworkInfo.GenesisRoot = fmt.Sprintf("0x%x", networkGenesis.GenesisValidatorsRoot)
+		data.NetworkInfo.GenesisValidatorsRoot = fmt.Sprintf("0x%x", networkGenesis.GenesisValidatorsRoot)
 	}
 
-	// Current state
-	currentState := &APICurrentState{
+	data.CurrentState = &APICurrentState{
 		CurrentSlot:          uint64(currentSlot),
 		CurrentEpoch:         uint64(currentEpoch),
 		CurrentEpochProgress: float64(100) * float64(currentSlotIndex) / float64(specs.SlotsPerEpoch),
@@ -190,43 +278,38 @@ func buildNetworkOverviewData(ctx context.Context) (*APINetworkOverviewData, tim
 		EpochDurationMs:      specs.SlotDurationMs * specs.SlotsPerEpoch,
 	}
 
-	// Checkpoints
-	checkpoints := &APICheckpoints{
+	data.Checkpoints = &APICheckpoints{
 		FinalizedEpoch: int64(finalizedEpoch),
 		JustifiedEpoch: int64(justifiedEpoch),
 	}
 	if finalizedRoot != consensus.NullRoot {
-		checkpoints.FinalizedRoot = fmt.Sprintf("0x%x", finalizedRoot)
+		data.Checkpoints.FinalizedRoot = fmt.Sprintf("0x%x", finalizedRoot)
 	}
 	if justifiedRoot != consensus.NullRoot {
-		checkpoints.JustifiedRoot = fmt.Sprintf("0x%x", justifiedRoot)
+		data.Checkpoints.JustifiedRoot = fmt.Sprintf("0x%x", justifiedRoot)
 	}
 
-	// Validator stats
-	validatorStats := &APIValidatorStats{}
+	data.ValidatorStats = &APIValidatorStats{}
 	recentEpochStatsValues, _ := services.GlobalBeaconService.GetRecentEpochStats(nil)
 	if recentEpochStatsValues != nil {
-		validatorStats.ActiveValidatorCount = recentEpochStatsValues.ActiveValidators
-		validatorStats.TotalActiveBalance = uint64(recentEpochStatsValues.ActiveBalance)
-		validatorStats.TotalEligibleEther = uint64(recentEpochStatsValues.EffectiveBalance)
+		data.ValidatorStats.ActiveValidatorCount = recentEpochStatsValues.ActiveValidators
+		data.ValidatorStats.TotalActiveBalance = uint64(recentEpochStatsValues.ActiveBalance)
+		data.ValidatorStats.TotalEligibleEther = uint64(recentEpochStatsValues.EffectiveBalance)
 		if recentEpochStatsValues.ActiveValidators > 0 {
-			validatorStats.AverageBalance = uint64(recentEpochStatsValues.ActiveBalance) / recentEpochStatsValues.ActiveValidators
+			data.ValidatorStats.AverageBalance = uint64(recentEpochStatsValues.ActiveBalance) / recentEpochStatsValues.ActiveValidators
 		}
-		validatorStats.TotalBalance = uint64(recentEpochStatsValues.TotalBalance)
+		data.ValidatorStats.TotalBalance = uint64(recentEpochStatsValues.TotalBalance)
 	}
 
-	// Queue stats (only for Electra era)
-	var queueStats *APIQueueStats
 	if specs.ElectraForkEpoch != nil && *specs.ElectraForkEpoch <= uint64(currentEpoch) {
-		activationQueueLength, exitQueueLength := services.GlobalBeaconService.GetBeaconIndexer().GetActivationExitQueueLengths(currentEpoch, nil)
+		activationQueueLength, exitQueueLength := beaconIndexer.GetActivationExitQueueLengths(currentEpoch, nil)
 
-		queueStats = &APIQueueStats{
+		data.QueueStats = &APIQueueStats{
 			EnteringValidatorCount: activationQueueLength,
 			ExitingValidatorCount:  exitQueueLength,
 		}
 
-		// Electra deposit queue
-		depositQueue := services.GlobalBeaconService.GetBeaconIndexer().GetLatestDepositQueue(nil)
+		depositQueue := beaconIndexer.GetLatestDepositQueue(nil)
 		if depositQueue != nil {
 			depositAmount := phase0.Gwei(0)
 			validatorCount := uint64(0)
@@ -244,41 +327,159 @@ func buildNetworkOverviewData(ctx context.Context) (*APINetworkOverviewData, tim
 				}
 			}
 
-			queueStats.EnteringValidatorCount += validatorCount
-			queueStats.EnteringEtherAmount = uint64(depositAmount)
+			data.QueueStats.EnteringValidatorCount += validatorCount
+			data.QueueStats.EnteringEtherAmount = uint64(depositAmount)
 
-			if validatorStats.TotalEligibleEther > 0 {
-				etherChurnPerEpoch := chainState.GetActivationExitChurnLimit(validatorStats.TotalEligibleEther)
-				queueStats.EtherChurnPerDay = etherChurnPerEpoch * 225 // ~225 epochs per day
+			if data.ValidatorStats.TotalEligibleEther > 0 {
+				etherChurnPerEpoch := chainState.GetActivationExitChurnLimit(data.ValidatorStats.TotalEligibleEther)
+				data.QueueStats.EtherChurnPerDay = etherChurnPerEpoch * 225 // ~225 epochs per day
 
-				if queueStats.EtherChurnPerDay > 0 {
-					// Calculate deposit time in seconds
-					depositDays := float64(depositAmount) / float64(queueStats.EtherChurnPerDay)
-					queueStats.DepositEstimatedTimeToProcess = uint64(depositDays * 24 * 60 * 60)
+				if data.QueueStats.EtherChurnPerDay > 0 {
+					depositDays := float64(depositAmount) / float64(data.QueueStats.EtherChurnPerDay)
+					data.QueueStats.DepositEstimatedTimeToProcess = uint64(depositDays * 24 * 60 * 60)
 
-					// Calculate exit time in seconds
-					// Assuming each validator has the average balance
-					exitEtherAmount := queueStats.ExitingValidatorCount * validatorStats.AverageBalance
-					exitDays := float64(exitEtherAmount) / float64(queueStats.EtherChurnPerDay)
-					queueStats.ExitEstimatedTimeToProcess = uint64(exitDays * 24 * 60 * 60)
+					exitEtherAmount := data.QueueStats.ExitingValidatorCount * data.ValidatorStats.AverageBalance
+					exitDays := float64(exitEtherAmount) / float64(data.QueueStats.EtherChurnPerDay)
+					data.QueueStats.ExitEstimatedTimeToProcess = uint64(exitDays * 24 * 60 * 60)
 				}
 			}
 		}
 	}
 
-	// Fork information (reuse from network forks API)
-	forks := buildNetworkForks(chainState)
-
-	data := &APINetworkOverviewData{
-		NetworkInfo:    networkInfo,
-		CurrentState:   currentState,
-		Checkpoints:    checkpoints,
-		ValidatorStats: validatorStats,
-		QueueStats:     queueStats,
-		Forks:          forks,
-		IsSynced:       isSynced,
-	}
+	data.Forks = buildNetworkForks(chainState)
 
 	cacheTimeout := time.Duration(specs.SlotDurationMs) * time.Millisecond
 	return data, cacheTimeout
+}
+
+func buildSafeNetworkOverview(input networkOverviewInput) *APINetworkOverviewData {
+	currentEpoch := uint64(0)
+	if input.SlotsPerEpoch > 0 {
+		currentEpoch = input.CurrentSlot / input.SlotsPerEpoch
+	}
+
+	warnings := []string{}
+	epochsSinceFinality := uint64(0)
+	if currentEpoch >= input.FinalizedEpoch {
+		epochsSinceFinality = currentEpoch - input.FinalizedEpoch
+	} else {
+		warnings = append(warnings, fmt.Sprintf("finalized_epoch %d is ahead of current_epoch %d", input.FinalizedEpoch, currentEpoch))
+	}
+
+	activeValidatorCount, pendingValidatorCount, exitedValidatorCount, totalValidatorCount := summarizeValidatorStatuses(input.ValidatorStatuses)
+	data := &APINetworkOverviewData{
+		CurrentSlot:           input.CurrentSlot,
+		CurrentEpoch:          currentEpoch,
+		FinalizedEpoch:        input.FinalizedEpoch,
+		EpochsSinceFinality:   epochsSinceFinality,
+		Finalizing:            epochsSinceFinality <= networkOverviewFinalizingThreshold,
+		ActiveValidatorCount:  activeValidatorCount,
+		TotalValidatorCount:   totalValidatorCount,
+		PendingValidatorCount: pendingValidatorCount,
+		ExitedValidatorCount:  exitedValidatorCount,
+		DataQualityWarnings:   warnings,
+		Metadata: APINetworkOverviewMetadata{
+			SlotsPerEpoch: input.SlotsPerEpoch,
+		},
+	}
+
+	if input.RawAggregate != nil {
+		data.RawAggregates = &APINetworkRawAggregates{
+			GlobalParticipationRate: input.RawAggregate.GlobalParticipationRate,
+			VoteParticipation:       input.RawAggregate.VoteParticipation,
+			AttestationsIndexed:     input.RawAggregate.AttestationsIndexed,
+			IndexedSlots:            input.RawAggregate.IndexedSlots,
+			ExpectedSlots:           input.RawAggregate.ExpectedSlots,
+			Source:                  networkOverviewRawAggregateSource,
+			Complete:                input.RawAggregate.Complete,
+		}
+
+		var participationWarning string
+		if data.Finalizing && input.RawAggregate.GlobalParticipationRate < networkOverviewParticipationQuorum {
+			participationWarning = fmt.Sprintf(
+				"vote participation aggregate reports %.1f%% while finalized_epoch is only %d epochs behind current_epoch; aggregate is likely incomplete",
+				input.RawAggregate.GlobalParticipationRate,
+				data.EpochsSinceFinality,
+			)
+			data.DataQualityWarnings = append(data.DataQualityWarnings, participationWarning)
+		}
+		data.Participation = buildNetworkOverviewParticipation(input.RawAggregate, participationWarning)
+	}
+
+	return data
+}
+
+func summarizeValidatorStatuses(statuses map[v1.ValidatorState]uint64) (active uint64, pending uint64, exited uint64, total uint64) {
+	for status, count := range statuses {
+		total += count
+
+		switch status {
+		case v1.ValidatorStatePendingInitialized, v1.ValidatorStatePendingQueued:
+			pending += count
+		case v1.ValidatorStateActiveOngoing, v1.ValidatorStateActiveExiting, v1.ValidatorStateActiveSlashed:
+			active += count
+		case v1.ValidatorStateExitedUnslashed, v1.ValidatorStateExitedSlashed, v1.ValidatorStateWithdrawalPossible, v1.ValidatorStateWithdrawalDone:
+			exited += count
+		}
+	}
+
+	return active, pending, exited, total
+}
+
+func buildNetworkOverviewParticipation(raw *networkOverviewRawAggregate, warning string) *APINetworkParticipation {
+	if raw == nil {
+		return nil
+	}
+
+	participation := &APINetworkParticipation{
+		Rate:          nil,
+		Source:        networkOverviewParticipationSource,
+		Complete:      raw.Complete && warning == "",
+		IndexedSlots:  raw.IndexedSlots,
+		ExpectedSlots: raw.ExpectedSlots,
+	}
+
+	if raw.Complete && warning == "" {
+		rate := raw.GlobalParticipationRate
+		participation.Rate = &rate
+	} else {
+		participation.Warning = networkOverviewParticipationWarnText
+		if warning != "" {
+			participation.Warning = warning
+		}
+	}
+
+	return participation
+}
+
+func getNetworkOverviewRawAggregate(ctx context.Context, epoch uint64, slotsPerEpoch uint64) *networkOverviewRawAggregate {
+	if slotsPerEpoch == 0 {
+		return nil
+	}
+
+	dbEpochs := services.GlobalBeaconService.GetDbEpochs(ctx, epoch, 1)
+	if len(dbEpochs) == 0 || dbEpochs[0] == nil {
+		return nil
+	}
+
+	return buildNetworkOverviewRawAggregate(dbEpochs[0], slotsPerEpoch)
+}
+
+func buildNetworkOverviewRawAggregate(dbEpoch *dbtypes.Epoch, slotsPerEpoch uint64) *networkOverviewRawAggregate {
+	if dbEpoch == nil || dbEpoch.Eligible == 0 || slotsPerEpoch == 0 {
+		return nil
+	}
+
+	globalParticipationRate := float64(dbEpoch.VotedTarget) * 100 / float64(dbEpoch.Eligible)
+	voteParticipation := float64(dbEpoch.VotedTotal) * 100 / float64(dbEpoch.Eligible)
+	indexedSlots := uint64(dbEpoch.BlockCount)
+
+	return &networkOverviewRawAggregate{
+		GlobalParticipationRate: globalParticipationRate,
+		VoteParticipation:       voteParticipation,
+		AttestationsIndexed:     dbEpoch.AttestationCount,
+		IndexedSlots:            indexedSlots,
+		ExpectedSlots:           slotsPerEpoch,
+		Complete:                indexedSlots >= slotsPerEpoch,
+	}
 }

--- a/handlers/api/network_overview_v1_test.go
+++ b/handlers/api/network_overview_v1_test.go
@@ -1,0 +1,265 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ethpandaops/dora/dbtypes"
+	"github.com/ethpandaops/dora/services"
+	v1 "github.com/ethpandaops/go-eth2-client/api/v1"
+)
+
+func TestNetworkOverviewWarnsWhenVoteAggregateContradictsFinality(t *testing.T) {
+	overview := buildSafeNetworkOverview(networkOverviewInput{
+		CurrentSlot:    34801,
+		SlotsPerEpoch:  32,
+		FinalizedEpoch: 1085,
+		ValidatorStatuses: map[v1.ValidatorState]uint64{
+			v1.ValidatorStateActiveOngoing:      12345,
+			v1.ValidatorStatePendingQueued:      10,
+			v1.ValidatorStateExitedUnslashed:    100,
+			v1.ValidatorStateWithdrawalPossible: 45,
+		},
+		RawAggregate: &networkOverviewRawAggregate{
+			GlobalParticipationRate: 58.4,
+			VoteParticipation:       58.4,
+			AttestationsIndexed:     35,
+			IndexedSlots:            32,
+			ExpectedSlots:           32,
+			Complete:                true,
+		},
+	})
+
+	if !overview.Finalizing {
+		t.Fatalf("expected overview to report finalizing")
+	}
+	if overview.EpochsSinceFinality != 2 {
+		t.Fatalf("expected epochs_since_finality 2, got %d", overview.EpochsSinceFinality)
+	}
+	if len(overview.DataQualityWarnings) != 1 {
+		t.Fatalf("expected one data quality warning, got %d", len(overview.DataQualityWarnings))
+	}
+	if !strings.Contains(overview.DataQualityWarnings[0], "vote participation aggregate reports 58.4%") {
+		t.Fatalf("unexpected warning: %q", overview.DataQualityWarnings[0])
+	}
+	if overview.Participation == nil {
+		t.Fatalf("expected participation provenance")
+	}
+	if overview.Participation.Rate != nil {
+		t.Fatalf("expected contradictory participation rate to be omitted, got %v", *overview.Participation.Rate)
+	}
+	if overview.Participation.Complete {
+		t.Fatalf("expected contradictory participation to be marked incomplete")
+	}
+	if overview.RawAggregates == nil || overview.RawAggregates.GlobalParticipationRate != 58.4 {
+		t.Fatalf("expected raw aggregate to retain the reported vote participation")
+	}
+}
+
+func TestNetworkOverviewIncompleteIndexOmitsTopLevelParticipationRate(t *testing.T) {
+	overview := buildSafeNetworkOverview(networkOverviewInput{
+		CurrentSlot:       34801,
+		SlotsPerEpoch:     32,
+		FinalizedEpoch:    1084,
+		ValidatorStatuses: map[v1.ValidatorState]uint64{},
+		RawAggregate: &networkOverviewRawAggregate{
+			GlobalParticipationRate: 83.2,
+			VoteParticipation:       83.2,
+			AttestationsIndexed:     35,
+			IndexedSlots:            5,
+			ExpectedSlots:           32,
+			Complete:                false,
+		},
+	})
+
+	responseBytes, err := json.Marshal(APINetworkOverviewResponse{
+		Status: "OK",
+		Data:   overview,
+	})
+	if err != nil {
+		t.Fatalf("marshal overview response: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(responseBytes, &response); err != nil {
+		t.Fatalf("unmarshal overview response: %v", err)
+	}
+	data := response["data"].(map[string]any)
+	if _, ok := data["participation_rate"]; ok {
+		t.Fatalf("overview must not expose a top-level participation_rate")
+	}
+	if overview.Participation == nil {
+		t.Fatalf("expected participation provenance")
+	}
+	if overview.Participation.Rate != nil {
+		t.Fatalf("expected incomplete participation rate to be null")
+	}
+	if overview.Participation.Complete {
+		t.Fatalf("expected incomplete participation source")
+	}
+	if overview.Participation.Warning != networkOverviewParticipationWarnText {
+		t.Fatalf("unexpected participation warning: %q", overview.Participation.Warning)
+	}
+}
+
+func TestNetworkOverviewCurrentSlotUsesActualHeadSlot(t *testing.T) {
+	overview := buildSafeNetworkOverview(networkOverviewInput{
+		CurrentSlot:    34801,
+		SlotsPerEpoch:  32,
+		FinalizedEpoch: 1085,
+	})
+
+	if overview.CurrentSlot != 34801 {
+		t.Fatalf("expected current_slot to remain actual head slot, got %d", overview.CurrentSlot)
+	}
+	if overview.CurrentEpoch != 1087 {
+		t.Fatalf("expected current_epoch derived from head slot, got %d", overview.CurrentEpoch)
+	}
+	if overview.CurrentSlot == overview.CurrentEpoch*overview.Metadata.SlotsPerEpoch {
+		t.Fatalf("current_slot was collapsed to epoch start slot")
+	}
+}
+
+func TestNetworkOverviewErrorEnvelopeIsNotSuccessful(t *testing.T) {
+	w := httptest.NewRecorder()
+	sendServerErrorResponse(w, "/api/v1/network/overview", "failed to build network overview")
+
+	if w.Code < http.StatusBadRequest {
+		t.Fatalf("expected non-2xx HTTP status, got %d", w.Code)
+	}
+
+	var response ApiResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal error response: %v", err)
+	}
+	if response.Status == "OK" {
+		t.Fatalf("non-OK response must not use OK status")
+	}
+	if response.Data != nil {
+		t.Fatalf("error response must not include successful data")
+	}
+}
+
+func TestNetworkOverviewHandlerUnavailableStateReturnsErrorEnvelope(t *testing.T) {
+	oldFrontendCache := services.GlobalFrontendCache
+	oldBeaconService := services.GlobalBeaconService
+	services.GlobalFrontendCache = nil
+	services.GlobalBeaconService = nil
+	defer func() {
+		services.GlobalFrontendCache = oldFrontendCache
+		services.GlobalBeaconService = oldBeaconService
+	}()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/network/overview", nil)
+	APINetworkOverviewV1(w, req)
+
+	if w.Code < http.StatusBadRequest {
+		t.Fatalf("expected non-2xx HTTP status, got %d", w.Code)
+	}
+
+	var response ApiResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal error response: %v", err)
+	}
+	if response.Status == "OK" {
+		t.Fatalf("unavailable overview must not use OK status")
+	}
+	if response.Data != nil {
+		t.Fatalf("unavailable overview must not include successful data")
+	}
+}
+
+func TestNetworkOverviewResponseContainsClientSnapshotFields(t *testing.T) {
+	overview := buildSafeNetworkOverview(networkOverviewInput{
+		CurrentSlot:    34801,
+		SlotsPerEpoch:  32,
+		FinalizedEpoch: 1085,
+		ValidatorStatuses: map[v1.ValidatorState]uint64{
+			v1.ValidatorStateActiveOngoing:   12345,
+			v1.ValidatorStatePendingQueued:   10,
+			v1.ValidatorStateExitedUnslashed: 145,
+		},
+	})
+	overview.NetworkInfo = &APINetworkInfo{}
+	overview.CurrentState = &APICurrentState{}
+	overview.Checkpoints = &APICheckpoints{}
+	overview.ValidatorStats = &APIValidatorStats{}
+	overview.Forks = []*APINetworkForkInfo{}
+	overview.IsSynced = true
+
+	responseBytes, err := json.Marshal(APINetworkOverviewResponse{
+		Status: "OK",
+		Data:   overview,
+	})
+	if err != nil {
+		t.Fatalf("marshal overview response: %v", err)
+	}
+
+	var response struct {
+		Status string         `json:"status"`
+		Data   map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(responseBytes, &response); err != nil {
+		t.Fatalf("unmarshal overview response: %v", err)
+	}
+	if response.Status != "OK" {
+		t.Fatalf("expected OK response, got %q", response.Status)
+	}
+
+	requiredFields := []string{
+		"current_slot",
+		"current_epoch",
+		"finalized_epoch",
+		"epochs_since_finality",
+		"finalizing",
+		"active_validator_count",
+		"total_validator_count",
+		"pending_validator_count",
+		"exited_validator_count",
+		"data_quality_warnings",
+		"metadata",
+		"network_info",
+		"current_state",
+		"checkpoints",
+		"validator_stats",
+		"forks",
+		"is_synced",
+	}
+	for _, field := range requiredFields {
+		if _, ok := response.Data[field]; !ok {
+			t.Fatalf("overview missing required field %q", field)
+		}
+	}
+
+	metadata, ok := response.Data["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("overview metadata has unexpected shape")
+	}
+	if metadata["slots_per_epoch"] != float64(32) {
+		t.Fatalf("expected metadata.slots_per_epoch 32, got %v", metadata["slots_per_epoch"])
+	}
+}
+
+func TestBuildNetworkOverviewRawAggregateMarksIncompleteIndex(t *testing.T) {
+	raw := buildNetworkOverviewRawAggregate(&dbtypes.Epoch{
+		Eligible:         100,
+		VotedTarget:      83,
+		VotedTotal:       85,
+		AttestationCount: 35,
+		BlockCount:       5,
+	}, 32)
+
+	if raw == nil {
+		t.Fatalf("expected raw aggregate")
+	}
+	if raw.Complete {
+		t.Fatalf("expected raw aggregate to be incomplete")
+	}
+	if raw.IndexedSlots != 5 || raw.ExpectedSlots != 32 {
+		t.Fatalf("unexpected indexed/expected slots: %d/%d", raw.IndexedSlots, raw.ExpectedSlots)
+	}
+}

--- a/handlers/api/network_overview_v1_test.go
+++ b/handlers/api/network_overview_v1_test.go
@@ -8,76 +8,80 @@ import (
 	"testing"
 
 	"github.com/ethpandaops/dora/dbtypes"
-	"github.com/ethpandaops/dora/services"
 	v1 "github.com/ethpandaops/go-eth2-client/api/v1"
 )
 
 func TestNetworkOverviewWarnsWhenVoteAggregateContradictsFinality(t *testing.T) {
-	overview := buildSafeNetworkOverview(networkOverviewInput{
-		CurrentSlot:    34801,
-		SlotsPerEpoch:  32,
-		FinalizedEpoch: 1085,
-		ValidatorStatuses: map[v1.ValidatorState]uint64{
-			v1.ValidatorStateActiveOngoing:      12345,
-			v1.ValidatorStatePendingQueued:      10,
-			v1.ValidatorStateExitedUnslashed:    100,
-			v1.ValidatorStateWithdrawalPossible: 45,
-		},
-		RawAggregate: &networkOverviewRawAggregate{
-			GlobalParticipationRate: 58.4,
-			VoteParticipation:       58.4,
-			AttestationsIndexed:     35,
-			IndexedSlots:            32,
-			ExpectedSlots:           32,
-			Complete:                true,
-		},
-	})
+	participation, warning := buildNetworkOverviewParticipation(&networkOverviewRawAggregate{
+		GlobalParticipationRate: 58.4,
+		VoteParticipation:       58.4,
+		AttestationsIndexed:     35,
+		IndexedSlots:            32,
+		ExpectedSlots:           32,
+		Complete:                true,
+	}, true, 2)
 
-	if !overview.Finalizing {
-		t.Fatalf("expected overview to report finalizing")
+	if warning == "" {
+		t.Fatalf("expected a data quality warning")
 	}
-	if overview.EpochsSinceFinality != 2 {
-		t.Fatalf("expected epochs_since_finality 2, got %d", overview.EpochsSinceFinality)
+	if !strings.Contains(warning, "vote participation aggregate reports 58.4%") {
+		t.Fatalf("unexpected warning: %q", warning)
 	}
-	if len(overview.DataQualityWarnings) != 1 {
-		t.Fatalf("expected one data quality warning, got %d", len(overview.DataQualityWarnings))
+	if participation.Rate != nil {
+		t.Fatalf("expected contradictory participation rate to be omitted, got %v", *participation.Rate)
 	}
-	if !strings.Contains(overview.DataQualityWarnings[0], "vote participation aggregate reports 58.4%") {
-		t.Fatalf("unexpected warning: %q", overview.DataQualityWarnings[0])
-	}
-	if overview.Participation == nil {
-		t.Fatalf("expected participation provenance")
-	}
-	if overview.Participation.Rate != nil {
-		t.Fatalf("expected contradictory participation rate to be omitted, got %v", *overview.Participation.Rate)
-	}
-	if overview.Participation.Complete {
+	if participation.Complete {
 		t.Fatalf("expected contradictory participation to be marked incomplete")
 	}
-	if overview.RawAggregates == nil || overview.RawAggregates.GlobalParticipationRate != 58.4 {
-		t.Fatalf("expected raw aggregate to retain the reported vote participation")
+}
+
+func TestNetworkOverviewCompleteAggregateExposesParticipationRate(t *testing.T) {
+	participation, warning := buildNetworkOverviewParticipation(&networkOverviewRawAggregate{
+		GlobalParticipationRate: 98.7,
+		VoteParticipation:       99.1,
+		AttestationsIndexed:     35,
+		IndexedSlots:            32,
+		ExpectedSlots:           32,
+		Complete:                true,
+	}, true, 2)
+
+	if warning != "" {
+		t.Fatalf("unexpected warning: %q", warning)
+	}
+	if !participation.Complete {
+		t.Fatalf("expected complete participation source")
+	}
+	if participation.Rate == nil || *participation.Rate != 98.7 {
+		t.Fatalf("expected participation rate 98.7, got %v", participation.Rate)
 	}
 }
 
 func TestNetworkOverviewIncompleteIndexOmitsTopLevelParticipationRate(t *testing.T) {
-	overview := buildSafeNetworkOverview(networkOverviewInput{
-		CurrentSlot:       34801,
-		SlotsPerEpoch:     32,
-		FinalizedEpoch:    1084,
-		ValidatorStatuses: map[v1.ValidatorState]uint64{},
-		RawAggregate: &networkOverviewRawAggregate{
-			GlobalParticipationRate: 83.2,
-			VoteParticipation:       83.2,
-			AttestationsIndexed:     35,
-			IndexedSlots:            5,
-			ExpectedSlots:           32,
-			Complete:                false,
-		},
-	})
+	participation, warning := buildNetworkOverviewParticipation(&networkOverviewRawAggregate{
+		GlobalParticipationRate: 83.2,
+		VoteParticipation:       83.2,
+		AttestationsIndexed:     35,
+		IndexedSlots:            5,
+		ExpectedSlots:           32,
+		Complete:                false,
+	}, true, 3)
+
+	if warning != "" {
+		t.Fatalf("unexpected data quality warning: %q", warning)
+	}
+	if participation.Rate != nil {
+		t.Fatalf("expected incomplete participation rate to be null")
+	}
+	if participation.Complete {
+		t.Fatalf("expected incomplete participation source")
+	}
+	if participation.Warning != networkOverviewParticipationWarnText {
+		t.Fatalf("unexpected participation warning: %q", participation.Warning)
+	}
 
 	responseBytes, err := json.Marshal(APINetworkOverviewResponse{
 		Status: "OK",
-		Data:   overview,
+		Data:   &APINetworkOverviewData{Participation: participation},
 	})
 	if err != nil {
 		t.Fatalf("marshal overview response: %v", err)
@@ -90,36 +94,6 @@ func TestNetworkOverviewIncompleteIndexOmitsTopLevelParticipationRate(t *testing
 	data := response["data"].(map[string]any)
 	if _, ok := data["participation_rate"]; ok {
 		t.Fatalf("overview must not expose a top-level participation_rate")
-	}
-	if overview.Participation == nil {
-		t.Fatalf("expected participation provenance")
-	}
-	if overview.Participation.Rate != nil {
-		t.Fatalf("expected incomplete participation rate to be null")
-	}
-	if overview.Participation.Complete {
-		t.Fatalf("expected incomplete participation source")
-	}
-	if overview.Participation.Warning != networkOverviewParticipationWarnText {
-		t.Fatalf("unexpected participation warning: %q", overview.Participation.Warning)
-	}
-}
-
-func TestNetworkOverviewCurrentSlotUsesActualHeadSlot(t *testing.T) {
-	overview := buildSafeNetworkOverview(networkOverviewInput{
-		CurrentSlot:    34801,
-		SlotsPerEpoch:  32,
-		FinalizedEpoch: 1085,
-	})
-
-	if overview.CurrentSlot != 34801 {
-		t.Fatalf("expected current_slot to remain actual head slot, got %d", overview.CurrentSlot)
-	}
-	if overview.CurrentEpoch != 1087 {
-		t.Fatalf("expected current_epoch derived from head slot, got %d", overview.CurrentEpoch)
-	}
-	if overview.CurrentSlot == overview.CurrentEpoch*overview.Metadata.SlotsPerEpoch {
-		t.Fatalf("current_slot was collapsed to epoch start slot")
 	}
 }
 
@@ -143,57 +117,38 @@ func TestNetworkOverviewErrorEnvelopeIsNotSuccessful(t *testing.T) {
 	}
 }
 
-func TestNetworkOverviewHandlerUnavailableStateReturnsErrorEnvelope(t *testing.T) {
-	oldFrontendCache := services.GlobalFrontendCache
-	oldBeaconService := services.GlobalBeaconService
-	services.GlobalFrontendCache = nil
-	services.GlobalBeaconService = nil
-	defer func() {
-		services.GlobalFrontendCache = oldFrontendCache
-		services.GlobalBeaconService = oldBeaconService
-	}()
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/network/overview", nil)
-	APINetworkOverviewV1(w, req)
-
-	if w.Code < http.StatusBadRequest {
-		t.Fatalf("expected non-2xx HTTP status, got %d", w.Code)
-	}
-
-	var response ApiResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
-		t.Fatalf("unmarshal error response: %v", err)
-	}
-	if response.Status == "OK" {
-		t.Fatalf("unavailable overview must not use OK status")
-	}
-	if response.Data != nil {
-		t.Fatalf("unavailable overview must not include successful data")
-	}
-}
-
 func TestNetworkOverviewResponseContainsClientSnapshotFields(t *testing.T) {
-	overview := buildSafeNetworkOverview(networkOverviewInput{
-		CurrentSlot:    34801,
-		SlotsPerEpoch:  32,
-		FinalizedEpoch: 1085,
-		ValidatorStatuses: map[v1.ValidatorState]uint64{
-			v1.ValidatorStateActiveOngoing:   12345,
-			v1.ValidatorStatePendingQueued:   10,
-			v1.ValidatorStateExitedUnslashed: 145,
-		},
+	activeCount, pendingCount, exitedCount, totalCount := summarizeValidatorStatuses(map[v1.ValidatorState]uint64{
+		v1.ValidatorStateActiveOngoing:   12345,
+		v1.ValidatorStatePendingQueued:   10,
+		v1.ValidatorStateExitedUnslashed: 145,
 	})
-	overview.NetworkInfo = &APINetworkInfo{}
-	overview.CurrentState = &APICurrentState{}
-	overview.Checkpoints = &APICheckpoints{}
-	overview.ValidatorStats = &APIValidatorStats{}
-	overview.Forks = []*APINetworkForkInfo{}
-	overview.IsSynced = true
+
+	if activeCount != 12345 || pendingCount != 10 || exitedCount != 145 || totalCount != 12500 {
+		t.Fatalf("unexpected validator status summary: %d/%d/%d/%d", activeCount, pendingCount, exitedCount, totalCount)
+	}
 
 	responseBytes, err := json.Marshal(APINetworkOverviewResponse{
 		Status: "OK",
-		Data:   overview,
+		Data: &APINetworkOverviewData{
+			NetworkInfo:           &APINetworkInfo{},
+			CurrentState:          &APICurrentState{},
+			Checkpoints:           &APICheckpoints{},
+			ValidatorStats:        &APIValidatorStats{},
+			Forks:                 []*APINetworkForkInfo{},
+			IsSynced:              true,
+			CurrentSlot:           34801,
+			CurrentEpoch:          1087,
+			FinalizedEpoch:        1085,
+			EpochsSinceFinality:   2,
+			Finalizing:            true,
+			ActiveValidatorCount:  activeCount,
+			TotalValidatorCount:   totalCount,
+			PendingValidatorCount: pendingCount,
+			ExitedValidatorCount:  exitedCount,
+			DataQualityWarnings:   []string{},
+			Metadata:              APINetworkOverviewMetadata{SlotsPerEpoch: 32},
+		},
 	})
 	if err != nil {
 		t.Fatalf("marshal overview response: %v", err)


### PR DESCRIPTION
## Summary
- Extends the existing /api/v1/network/overview response instead of replacing its legacy shape.
- Keeps network_info, current_state, checkpoints, validator_stats, queue_stats, forks, and is_synced for existing consumers.
- Adds Panda-safe top-level health fields for canonical head slot/epoch, finalized epoch, epochs since finality, finalizing, validator counts, data quality warnings, and slots_per_epoch metadata.
- Moves vote-derived participation behind provenance, returning a null rate for incomplete or contradictory aggregates and keeping raw values under raw_aggregates.
- Regenerates Swagger docs and adds regression tests for the finality and participation invariants.

## Impact
Existing overview consumers can continue reading the previous nested fields. Panda can use the new top-level fields from GET /api/v1/network/overview without stitching multiple endpoints or trusting incomplete vote aggregates.

## Root Cause
The previous overview did not expose a health-safe contract around observed head slot, authoritative finality, or vote aggregate completeness.

## Validation
- go test ./handlers/api
- go test ./...
