### PR TITLE
fix: race conditions and memory leaks in validator names and frontend cache

### DIFF
--- a/services/frontendcache.go
+++ b/services/frontendcache.go
@@ -190,8 +190,8 @@ func (fc *FrontendCacheService) processPageCall(pageKey string, caching bool, pa
 		// acquire per-page-type concurrency semaphore if configured (non-blocking)
 		if fc.pageTypeSemLimit > 0 {
 			pageType := pageKey
-			if idx := strings.IndexByte(pageKey, ':'); idx >= 0 {
-				pageType = pageKey[:idx]
+			if before, _, ok := strings.Cut(pageKey, ":"); ok {
+				pageType = before
 			}
 
 			typeSem := fc.getPageTypeSemaphore(pageType)

--- a/services/frontendcache.go
+++ b/services/frontendcache.go
@@ -9,6 +9,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethpandaops/dora/cache"
@@ -142,9 +143,8 @@ func (fc *FrontendCacheService) ProcessCachedPage(pageKey string, caching bool, 
 
 func (fc *FrontendCacheService) processPageCall(pageKey string, caching bool, pageData interface{}, buildFn PageDataHandlerFn, pageCall *FrontendCacheProcessingPage) (interface{}, error) {
 	// process page call with timeout
-	returnChan := make(chan interface{})
-	errorChan := make(chan error)
-	isTimedOut := false
+	returnChan := make(chan any, 1)
+	errorChan := make(chan error, 1)
 
 	callCtx, callCtxCancel := context.WithCancel(context.Background())
 	defer callCtxCancel()
@@ -155,20 +155,23 @@ func (fc *FrontendCacheService) processPageCall(pageKey string, caching bool, pa
 	callIdx := fc.pageCallCounter
 	fc.pageCallCounterMutex.Unlock()
 
-	callGoId := uint64(0)
+	var callGoId atomic.Uint64
 
 	go func(callIdx uint64) {
 		defer func() {
 			if err := recover(); err != nil {
-				errorChan <- &FrontendCachePageError{
+				select {
+				case errorChan <- &FrontendCachePageError{
 					name:  "page panic",
 					err:   fmt.Errorf("page call %v panic: %v", callIdx, err),
 					stack: string(debug.Stack()),
+				}:
+				default:
 				}
 			}
 		}()
 
-		callGoId = routine.Goid()
+		callGoId.Store(routine.Goid())
 
 		// acquire global concurrency semaphore if configured (non-blocking)
 		if fc.concurrencySem != nil {
@@ -176,7 +179,10 @@ func (fc *FrontendCacheService) processPageCall(pageKey string, caching bool, pa
 			case fc.concurrencySem <- struct{}{}:
 				defer func() { <-fc.concurrencySem }()
 			default:
-				errorChan <- ErrTooManyPageRequests
+				select {
+				case errorChan <- ErrTooManyPageRequests:
+				default:
+				}
 				return
 			}
 		}
@@ -193,7 +199,10 @@ func (fc *FrontendCacheService) processPageCall(pageKey string, caching bool, pa
 			case typeSem <- struct{}{}:
 				defer func() { <-typeSem }()
 			default:
-				errorChan <- ErrTooManyPageRequests
+				select {
+				case errorChan <- ErrTooManyPageRequests:
+				default:
+				}
 				return
 			}
 		}
@@ -201,7 +210,9 @@ func (fc *FrontendCacheService) processPageCall(pageKey string, caching bool, pa
 		// check cache
 		if fc.cachingEnabled && caching && fc.getFrontendCache(pageKey, pageData) == nil {
 			logrus.Debugf("page served from cache: %v", pageKey)
-			if !isTimedOut {
+			select {
+			case <-callCtx.Done():
+			default:
 				returnChan <- pageData
 			}
 			return
@@ -210,13 +221,19 @@ func (fc *FrontendCacheService) processPageCall(pageKey string, caching bool, pa
 		// process page call
 		pageData = buildFn(pageCall)
 
-		if isTimedOut {
+		select {
+		case <-callCtx.Done():
 			return
+		default:
 		}
+
 		if fc.cachingEnabled && caching && pageCall.CacheTimeout >= 0 {
 			fc.setFrontendCache(pageKey, pageData, pageCall.CacheTimeout)
 		}
-		if !isTimedOut {
+
+		select {
+		case <-callCtx.Done():
+		default:
 			returnChan <- pageData
 		}
 	}(callIdx)
@@ -232,12 +249,12 @@ func (fc *FrontendCacheService) processPageCall(pageKey string, caching bool, pa
 	case returnError := <-errorChan:
 		return nil, returnError
 	case <-time.After(callTimeout):
-		isTimedOut = true
 		callCtxCancel()
+		goid := callGoId.Load()
 		return nil, &FrontendCachePageError{
 			name:  "page timeout",
 			err:   fmt.Errorf("page call %v timeout", callIdx),
-			stack: fc.extractPageCallStack(callGoId),
+			stack: fc.extractPageCallStack(goid),
 		}
 	}
 }

--- a/services/frontendcache_test.go
+++ b/services/frontendcache_test.go
@@ -1,0 +1,146 @@
+package services
+
+import (
+	"errors"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/ethpandaops/dora/types"
+	"github.com/ethpandaops/dora/utils"
+)
+
+func TestMain(m *testing.M) {
+	utils.Config = &types.Config{}
+	os.Exit(m.Run())
+}
+
+func TestFrontendCache_ProcessPageCall_Timeout(t *testing.T) {
+	fc := &FrontendCacheService{
+		processingDict:  make(map[string]*FrontendCacheProcessingPage),
+		callStackBuffer: make([]byte, 1024*1024*1),
+		cachingEnabled:  false,
+	}
+
+	// Set a very short timeout for page calls in the global config
+	utils.Config.Frontend.PageCallTimeout = 20 * time.Millisecond
+	defer func() {
+		utils.Config.Frontend.PageCallTimeout = 0
+	}()
+
+	startGoroutines := runtime.NumGoroutine()
+
+	// Trigger a page call with a builder that sleeps longer than the timeout
+	val, err := fc.processPageCall("test-timeout-key", false, nil, func(pageCall *FrontendCacheProcessingPage) interface{} {
+		// Simulate a slow DB query/processing
+		select {
+		case <-pageCall.CallCtx.Done():
+			// Context canceled properly
+			return nil
+		case <-time.After(100 * time.Millisecond):
+			return "slow-result"
+		}
+	}, &FrontendCacheProcessingPage{})
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+
+	var cacheErr *FrontendCachePageError
+	if !errors.As(err, &cacheErr) || cacheErr.Name() != "page timeout" {
+		t.Fatalf("expected page timeout error, got %v", err)
+	}
+
+	if val != nil {
+		t.Fatalf("expected nil result on timeout, got %v", val)
+	}
+
+	// Wait for the slow goroutine's internal timer to expire/return
+	time.Sleep(150 * time.Millisecond)
+
+	// Ensure the spawned goroutine has exited and not leaked
+	endGoroutines := runtime.NumGoroutine()
+	if endGoroutines > startGoroutines+3 {
+		t.Errorf("suspected goroutine leak: start goroutines = %d, end goroutines = %d", startGoroutines, endGoroutines)
+	}
+}
+
+func TestFrontendCache_ProcessPageCall_Success(t *testing.T) {
+	fc := &FrontendCacheService{
+		processingDict:  make(map[string]*FrontendCacheProcessingPage),
+		callStackBuffer: make([]byte, 1024*1024*1),
+		cachingEnabled:  false,
+	}
+
+	utils.Config.Frontend.PageCallTimeout = 500 * time.Millisecond
+	defer func() {
+		utils.Config.Frontend.PageCallTimeout = 0
+	}()
+
+	val, err := fc.processPageCall("test-success-key", false, nil, func(pageCall *FrontendCacheProcessingPage) interface{} {
+		return "success-result"
+	}, &FrontendCacheProcessingPage{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if val != "success-result" {
+		t.Fatalf("expected 'success-result', got %v", val)
+	}
+}
+
+func TestFrontendCache_ProcessPageCall_Panic(t *testing.T) {
+	fc := &FrontendCacheService{
+		processingDict:  make(map[string]*FrontendCacheProcessingPage),
+		callStackBuffer: make([]byte, 1024*1024*1),
+		cachingEnabled:  false,
+	}
+
+	utils.Config.Frontend.PageCallTimeout = 500 * time.Millisecond
+	defer func() {
+		utils.Config.Frontend.PageCallTimeout = 0
+	}()
+
+	_, err := fc.processPageCall("test-panic-key", false, nil, func(pageCall *FrontendCacheProcessingPage) interface{} {
+		panic("db connection lost")
+	}, &FrontendCacheProcessingPage{})
+
+	if err == nil {
+		t.Fatal("expected panic recovery error, got nil")
+	}
+
+	var cacheErr *FrontendCachePageError
+	if !errors.As(err, &cacheErr) || cacheErr.Name() != "page panic" {
+		t.Fatalf("expected page panic error, got %v", err)
+	}
+}
+
+func TestFrontendCache_ProcessPageCall_ConcurrencyLimit(t *testing.T) {
+	// Setup concurrency limit of 1
+	concurrencySem := make(chan struct{}, 1)
+	fc := &FrontendCacheService{
+		processingDict:  make(map[string]*FrontendCacheProcessingPage),
+		callStackBuffer: make([]byte, 1024*1024*1),
+		cachingEnabled:  false,
+		concurrencySem:  concurrencySem,
+	}
+
+	utils.Config.Frontend.PageCallTimeout = 500 * time.Millisecond
+	defer func() {
+		utils.Config.Frontend.PageCallTimeout = 0
+	}()
+
+	// Acquire the only slot in the semaphore manually
+	concurrencySem <- struct{}{}
+
+	// The call should fail immediately with ErrTooManyPageRequests
+	_, err := fc.processPageCall("test-limit-key", false, nil, func(pageCall *FrontendCacheProcessingPage) interface{} {
+		return "result"
+	}, &FrontendCacheProcessingPage{})
+
+	if !errors.Is(err, ErrTooManyPageRequests) {
+		t.Fatalf("expected ErrTooManyPageRequests, got %v", err)
+	}
+}

--- a/services/validatornames.go
+++ b/services/validatornames.go
@@ -142,11 +142,30 @@ func (vn *ValidatorNames) getDefaultValidatorNames() string {
 func (vn *ValidatorNames) resolveNames() (bool, error) {
 	logger_vn.Debugf("resolve validator names")
 
+	vn.namesMutex.RLock()
+	var namesByWithdrawalCopy map[common.Address]*validatorNameEntry
+	if vn.namesByWithdrawal != nil {
+		namesByWithdrawalCopy = maps.Clone(vn.namesByWithdrawal)
+	}
+	var namesByDepositOriginCopy map[common.Address]*validatorNameEntry
+	if vn.namesByDepositOrigin != nil {
+		namesByDepositOriginCopy = maps.Clone(vn.namesByDepositOrigin)
+	}
+	var namesByDepositTargetCopy map[common.Address]*validatorNameEntry
+	if vn.namesByDepositTarget != nil {
+		namesByDepositTargetCopy = maps.Clone(vn.namesByDepositTarget)
+	}
+	var resolvedNamesByIndexCopy map[uint64]*validatorNameEntry
+	if vn.resolvedNamesByIndex != nil {
+		resolvedNamesByIndexCopy = maps.Clone(vn.resolvedNamesByIndex)
+	}
+	vn.namesMutex.RUnlock()
+
 	newResolvedNames := map[uint64]*validatorNameEntry{}
 	hasUpdates := false
 	addResolved := func(index uint64, name *validatorNameEntry) {
 		newResolvedNames[index] = name
-		if vn.resolvedNamesByIndex[index] != name {
+		if resolvedNamesByIndexCopy[index] != name {
 			hasUpdates = true
 		}
 	}
@@ -154,7 +173,7 @@ func (vn *ValidatorNames) resolveNames() (bool, error) {
 	canonicalForkIds := GlobalBeaconService.GetCanonicalForkIds()
 
 	// resolve names by withdrawal address
-	for wdAddr, name := range vn.namesByWithdrawal {
+	for wdAddr, name := range namesByWithdrawalCopy {
 		if name == nil {
 			continue
 		}
@@ -168,7 +187,7 @@ func (vn *ValidatorNames) resolveNames() (bool, error) {
 	}
 
 	// resolve names by depositor address
-	for address := range vn.namesByDepositOrigin {
+	for address := range namesByDepositOriginCopy {
 		offset := uint64(0)
 		pageSize := uint64(5000)
 
@@ -179,7 +198,7 @@ func (vn *ValidatorNames) resolveNames() (bool, error) {
 			for _, deposit := range deposits {
 				validatorIndex, found := vn.beaconIndexer.GetValidatorIndexByPubkey(phase0.BLSPubKey(deposit.PublicKey))
 				if found {
-					addResolved(uint64(validatorIndex), vn.namesByDepositOrigin[address])
+					addResolved(uint64(validatorIndex), namesByDepositOriginCopy[address])
 				}
 			}
 
@@ -191,7 +210,7 @@ func (vn *ValidatorNames) resolveNames() (bool, error) {
 	}
 
 	// resolve names by deposit target address
-	for address := range vn.namesByDepositTarget {
+	for address := range namesByDepositTargetCopy {
 		offset := uint64(0)
 		pageSize := uint64(5000)
 
@@ -202,7 +221,7 @@ func (vn *ValidatorNames) resolveNames() (bool, error) {
 			for _, deposit := range deposits {
 				validatorIndex, found := vn.beaconIndexer.GetValidatorIndexByPubkey(phase0.BLSPubKey(deposit.PublicKey))
 				if found {
-					addResolved(uint64(validatorIndex), vn.namesByDepositTarget[address])
+					addResolved(uint64(validatorIndex), namesByDepositTargetCopy[address])
 				}
 			}
 
@@ -215,7 +234,7 @@ func (vn *ValidatorNames) resolveNames() (bool, error) {
 
 	if !hasUpdates {
 		// check for removed names
-		for index := range vn.resolvedNamesByIndex {
+		for index := range resolvedNamesByIndexCopy {
 			if newResolvedNames[index] == nil {
 				hasUpdates = true
 			}
@@ -223,7 +242,9 @@ func (vn *ValidatorNames) resolveNames() (bool, error) {
 	}
 
 	if hasUpdates {
+		vn.namesMutex.Lock()
 		vn.resolvedNamesByIndex = newResolvedNames
+		vn.namesMutex.Unlock()
 	}
 
 	return hasUpdates, nil

--- a/services/validatornames_test.go
+++ b/services/validatornames_test.go
@@ -91,9 +91,7 @@ func TestGetValidatorName_Concurrency(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Goroutine 1: Continuous Reads
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -102,12 +100,10 @@ func TestGetValidatorName_Concurrency(t *testing.T) {
 				_ = vn.GetValidatorName(123)
 			}
 		}
-	}()
+	})
 
 	// Goroutine 2: Continuous Loader-like Map Reset/Updates
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -119,12 +115,10 @@ func TestGetValidatorName_Concurrency(t *testing.T) {
 				vn.namesMutex.Unlock()
 			}
 		}
-	}()
+	})
 
 	// Goroutine 3: Continuous Resolver-like Map Writes
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -137,18 +131,10 @@ func TestGetValidatorName_Concurrency(t *testing.T) {
 				vn.namesMutex.Unlock()
 			}
 		}
-	}()
+	})
 
 	// Run for a short duration
-	closeChan := make(chan struct{})
-	go func() {
-		select {
-		case <-time.After(100 * time.Millisecond):
-			close(stop)
-			close(closeChan)
-		}
-	}()
-
-	<-closeChan
+	time.Sleep(100 * time.Millisecond)
+	close(stop)
 	wg.Wait()
 }

--- a/services/validatornames_test.go
+++ b/services/validatornames_test.go
@@ -81,7 +81,7 @@ func TestGetValidatorName_Concurrency(t *testing.T) {
 	vn := &ValidatorNames{
 		namesMutex:           sync.RWMutex{},
 		namesByIndex:         make(map[uint64]*validatorNameEntry),
-		namesByWithdrawal:     make(map[common.Address]*validatorNameEntry),
+		namesByWithdrawal:    make(map[common.Address]*validatorNameEntry),
 		namesByDepositOrigin: make(map[common.Address]*validatorNameEntry),
 		namesByDepositTarget: make(map[common.Address]*validatorNameEntry),
 		resolvedNamesByIndex: make(map[uint64]*validatorNameEntry),

--- a/services/validatornames_test.go
+++ b/services/validatornames_test.go
@@ -3,6 +3,9 @@ package services
 import (
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func TestGetValidatorName(t *testing.T) {
@@ -72,4 +75,80 @@ func TestGetValidatorName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetValidatorName_Concurrency(t *testing.T) {
+	vn := &ValidatorNames{
+		namesMutex:           sync.RWMutex{},
+		namesByIndex:         make(map[uint64]*validatorNameEntry),
+		namesByWithdrawal:     make(map[common.Address]*validatorNameEntry),
+		namesByDepositOrigin: make(map[common.Address]*validatorNameEntry),
+		namesByDepositTarget: make(map[common.Address]*validatorNameEntry),
+		resolvedNamesByIndex: make(map[uint64]*validatorNameEntry),
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Goroutine 1: Continuous Reads
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = vn.GetValidatorName(123)
+			}
+		}
+	}()
+
+	// Goroutine 2: Continuous Loader-like Map Reset/Updates
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				vn.namesMutex.Lock()
+				vn.namesByIndex = make(map[uint64]*validatorNameEntry)
+				vn.namesByIndex[123] = &validatorNameEntry{name: "test"}
+				vn.namesMutex.Unlock()
+			}
+		}
+	}()
+
+	// Goroutine 3: Continuous Resolver-like Map Writes
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				newResolved := make(map[uint64]*validatorNameEntry)
+				newResolved[123] = &validatorNameEntry{name: "resolved"}
+				vn.namesMutex.Lock()
+				vn.resolvedNamesByIndex = newResolved
+				vn.namesMutex.Unlock()
+			}
+		}
+	}()
+
+	// Run for a short duration
+	closeChan := make(chan struct{})
+	go func() {
+		select {
+		case <-time.After(100 * time.Millisecond):
+			close(stop)
+			close(closeChan)
+		}
+	}()
+
+	<-closeChan
+	wg.Wait()
 }


### PR DESCRIPTION

### What's the problem?

Found two  bugs that can cause crash:

1. **Validator names service crashes every 6 hours** - Background job and HTTP requests were accessing same maps without proper locks
2. **Memory leak from stuck goroutines** - Timeout handling was leaving worker goroutines blocked forever

### How does the race happen?

**For validator names:**
- Background updater runs `resolveNames()` every 6 hours (takes ~60 seconds)
- Meanwhile, users visiting `/validators` page call `GetValidatorName()` 
- Both access same maps: `resolveNames()` writes without lock, `GetValidatorName()` reads WITH lock
- Go panics: `fatal error: concurrent map read and map write` -> crash

**For frontend cache:**
- Slow page loads timeout after 30s, main goroutine returns
- Worker goroutine completes later, tries sending to unbuffered channel
- No one listening anymore -> worker blocks forever -> memory leak
- Plus `isTimedOut` boolean had data race