### PR TITLE
Gloas: consistent execution-request slot attribution & deposit queue fixes

### DIFF
--- a/cmd/dora-utils/migrate.go
+++ b/cmd/dora-utils/migrate.go
@@ -49,6 +49,7 @@ func init() {
 
 	// Additional options
 	migrateCmd.Flags().String("limit-tables", "", "Limit tables to migrate (comma separated list)")
+	migrateCmd.Flags().String("exclude-tables", "", "Exclude tables from migration (comma separated list)")
 	migrateCmd.Flags().BoolP("debug", "d", false, "Enable debug mode")
 
 	// Mark required flags
@@ -61,6 +62,7 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 	sourceEngine, _ := cmd.Flags().GetString("source-engine")
 	targetEngine, _ := cmd.Flags().GetString("target-engine")
 	limitTablesStr, _ := cmd.Flags().GetString("limit-tables")
+	excludeTablesStr, _ := cmd.Flags().GetString("exclude-tables")
 
 	// Source database flags
 	sourceSqlitePath, _ := cmd.Flags().GetString("source-sqlite-path")
@@ -91,6 +93,11 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 		limitTables = strings.Split(limitTablesStr, ",")
 	}
 
+	excludeTables := make([]string, 0)
+	if excludeTablesStr != "" {
+		excludeTables = strings.Split(excludeTablesStr, ",")
+	}
+
 	sourceConfig := DbConfig{Engine: sourceEngine}
 	targetConfig := DbConfig{Engine: targetEngine}
 
@@ -114,7 +121,7 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 		targetConfig.Pgsql.Name = targetPgsqlDb
 	}
 
-	if err := migrateDatabase(sourceConfig, targetConfig, limitTables); err != nil {
+	if err := migrateDatabase(sourceConfig, targetConfig, limitTables, excludeTables); err != nil {
 		return fmt.Errorf("migration failed: %v", err)
 	}
 
@@ -122,7 +129,7 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func migrateDatabase(source, target DbConfig, limitTables []string) error {
+func migrateDatabase(source, target DbConfig, limitTables []string, excludeTables []string) error {
 	var sourceDb *sqlx.DB
 	var err error
 
@@ -178,6 +185,17 @@ func migrateDatabase(source, target DbConfig, limitTables []string) error {
 		filteredTables := make([]string, 0)
 		for _, table := range tables {
 			if slices.Contains(limitTables, table) {
+				filteredTables = append(filteredTables, table)
+			}
+		}
+		tables = filteredTables
+	}
+
+	// Filter tables if excludeTables is provided
+	if len(excludeTables) > 0 {
+		filteredTables := make([]string, 0)
+		for _, table := range tables {
+			if !slices.Contains(excludeTables, table) {
 				filteredTables = append(filteredTables, table)
 			}
 		}

--- a/db/deposits.go
+++ b/db/deposits.go
@@ -61,6 +61,50 @@ func InsertDeposits(ctx context.Context, tx *sqlx.Tx, deposits []*dbtypes.Deposi
 	return nil
 }
 
+// GetDepositRequestsBySlots returns canonical deposit request rows whose
+// slot_number is in the given set, ordered by (slot_number, slot_index). It is
+// used to resolve the EL deposit index of queue entries that were reordered
+// (postponed) and can no longer be aligned by queue position, matching them by
+// their PendingDeposit.slot.
+func GetDepositRequestsBySlots(ctx context.Context, slots []uint64, canonicalForkIds []uint64) ([]*dbtypes.Deposit, error) {
+	deposits := []*dbtypes.Deposit{}
+	if len(slots) == 0 {
+		return deposits, nil
+	}
+
+	// SQLite caps bound variables (default 999); chunk to stay well below that.
+	const maxParams = 900
+
+	for start := 0; start < len(slots); start += maxParams {
+		end := min(start+maxParams, len(slots))
+		chunk := slots[start:end]
+
+		var sql strings.Builder
+		args := make([]any, 0, len(chunk)+len(canonicalForkIds))
+		fmt.Fprint(&sql, `SELECT deposit_index, slot_number, slot_index, slot_root, orphaned, publickey, withdrawalcredentials, amount, fork_id, cred_type
+			FROM deposits
+			WHERE slot_number IN (`)
+		for _, slot := range chunk {
+			args = append(args, slot)
+		}
+		appendDollarPlaceholders(&sql, 1, len(chunk), ", ")
+		fmt.Fprint(&sql, ")")
+
+		filterOp := "AND"
+		appendWithOrphanedFilter(&sql, &args, &filterOp, 0, canonicalForkIds, "deposits.fork_id")
+
+		fmt.Fprint(&sql, " ORDER BY slot_number, slot_index")
+
+		var chunkResult []*dbtypes.Deposit
+		if err := ReaderDb.SelectContext(ctx, &chunkResult, sql.String(), args...); err != nil {
+			return nil, fmt.Errorf("error fetching deposit requests by slots: %w", err)
+		}
+		deposits = append(deposits, chunkResult...)
+	}
+
+	return deposits, nil
+}
+
 func GetDepositsFiltered(ctx context.Context, offset uint64, limit uint32, canonicalForkIds []uint64, filter *dbtypes.DepositFilter, txFilter *dbtypes.DepositTxFilter) ([]*dbtypes.DepositWithTx, uint64, error) {
 	var sql strings.Builder
 	args := []any{}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3009,6 +3009,9 @@ const docTemplate = `{
                 "index": {
                     "type": "integer"
                 },
+                "postponed": {
+                    "type": "boolean"
+                },
                 "public_key": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3006,6 +3006,9 @@
                 "index": {
                     "type": "integer"
                 },
+                "postponed": {
+                    "type": "boolean"
+                },
                 "public_key": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -396,6 +396,8 @@ definitions:
         type: integer
       index:
         type: integer
+      postponed:
+        type: boolean
       public_key:
         type: string
       queue_position:

--- a/handlers/api/deposits_queue_v1.go
+++ b/handlers/api/deposits_queue_v1.go
@@ -227,10 +227,10 @@ func APIDepositsQueueV1(w http.ResponseWriter, r *http.Request) {
 				for _, item := range selectedEntries {
 					queueEntry := item.entry
 
-					// Postponed deposits have no churn-based estimate (they wait for their
-					// validator to become withdrawable), so EstimatedTime is left at 0.
+					// EpochEstimate is the churn-based epoch for normal deposits and the
+					// validator's withdrawable epoch for postponed ones; 0 means unknown.
 					estimatedTime := int64(0)
-					if !queueEntry.Postponed {
+					if queueEntry.EpochEstimate > 0 {
 						estimatedTime = chainState.EpochToTime(queueEntry.EpochEstimate).Unix()
 					}
 

--- a/handlers/api/deposits_queue_v1.go
+++ b/handlers/api/deposits_queue_v1.go
@@ -46,6 +46,7 @@ type APIDepositQueueInfo struct {
 	ValidatorStatus       string `json:"validator_status"`
 	Amount                uint64 `json:"amount"`
 	WithdrawalCredentials string `json:"withdrawal_credentials"`
+	Postponed             bool   `json:"postponed"`
 	TxHash                string `json:"tx_hash,omitempty"`
 	TxOrigin              string `json:"tx_origin,omitempty"`
 	TxTarget              string `json:"tx_target,omitempty"`
@@ -225,7 +226,13 @@ func APIDepositsQueueV1(w http.ResponseWriter, r *http.Request) {
 
 				for _, item := range selectedEntries {
 					queueEntry := item.entry
-					estimatedTime := chainState.EpochToTime(queueEntry.EpochEstimate).Unix()
+
+					// Postponed deposits have no churn-based estimate (they wait for their
+					// validator to become withdrawable), so EstimatedTime is left at 0.
+					estimatedTime := int64(0)
+					if !queueEntry.Postponed {
+						estimatedTime = chainState.EpochToTime(queueEntry.EpochEstimate).Unix()
+					}
 
 					depositInfo := &APIDepositQueueInfo{
 						QueuePosition:         queueEntry.QueuePos,
@@ -233,6 +240,7 @@ func APIDepositsQueueV1(w http.ResponseWriter, r *http.Request) {
 						PublicKey:             fmt.Sprintf("0x%x", queueEntry.PendingDeposit.Pubkey[:]),
 						WithdrawalCredentials: fmt.Sprintf("0x%x", queueEntry.PendingDeposit.WithdrawalCredentials[:]),
 						Amount:                uint64(queueEntry.PendingDeposit.Amount),
+						Postponed:             queueEntry.Postponed,
 					}
 
 					// Set transaction details if available

--- a/handlers/deposits.go
+++ b/handlers/deposits.go
@@ -376,13 +376,21 @@ func buildDepositsPageData(ctx context.Context, firstEpoch uint64, pageSize uint
 				wdCreds := queueEntry.PendingDeposit.WithdrawalCredentials[:]
 				isBuilder := len(wdCreds) > 0 && wdCreds[0] == 0x03
 
+				// Postponed deposits have no churn-based estimate (they wait for their
+				// validator to become withdrawable), so EstimatedTime is left unset.
+				var estimatedTime time.Time
+				if !queueEntry.Postponed {
+					estimatedTime = chainState.EpochToTime(queueEntry.EpochEstimate)
+				}
+
 				depositData := &models.DepositsPageDataQueuedDeposit{
 					QueuePosition:         queueEntry.QueuePos,
-					EstimatedTime:         chainState.EpochToTime(queueEntry.EpochEstimate),
+					EstimatedTime:         estimatedTime,
 					PublicKey:             queueEntry.PendingDeposit.Pubkey[:],
 					Withdrawalcredentials: wdCreds,
 					Amount:                uint64(queueEntry.PendingDeposit.Amount),
 					IsBuilder:             isBuilder,
+					Postponed:             queueEntry.Postponed,
 				}
 
 				if validatorIdx, found := services.GlobalBeaconService.GetValidatorIndexByPubkey(phase0.BLSPubKey(depositData.PublicKey)); !found {
@@ -447,7 +455,6 @@ func buildDepositsPageData(ctx context.Context, firstEpoch uint64, pageSize uint
 					if tx, txFound := txDetailsMap[depositData.Index]; txFound {
 						depositData.HasTransaction = true
 						depositData.TransactionHash = tx.TxHash
-						depositData.Withdrawalcredentials = tx.WithdrawalCredentials
 						depositData.TransactionDetails = &models.DepositsPageDataQueuedDepositTxDetails{
 							BlockNumber: tx.BlockNumber,
 							BlockHash:   fmt.Sprintf("%#x", tx.BlockRoot),

--- a/handlers/deposits.go
+++ b/handlers/deposits.go
@@ -140,7 +140,11 @@ func buildDepositsPageData(ctx context.Context, firstEpoch uint64, pageSize uint
 		pageData.EtherChurnPerEpoch = chainState.GetActivationExitChurnLimit(totalEligibleEther)
 		pageData.EtherChurnPerDay = pageData.EtherChurnPerEpoch * 225
 
-		pageData.NewDepositProcessAfter = chainState.EpochToTime(queuedDeposits.QueueEstimation)
+		// QueueEstimation is 0 for an empty or all-postponed queue; leave the time unset so
+		// the UI shows "--" instead of a bogus estimate.
+		if queuedDeposits.QueueEstimation > 0 {
+			pageData.NewDepositProcessAfter = chainState.EpochToTime(queuedDeposits.QueueEstimation)
+		}
 	} else {
 		// pre-electra
 		pageData.ValidatorsPerEpoch = chainState.GetValidatorChurnLimit(activeValidatorCount)
@@ -376,10 +380,10 @@ func buildDepositsPageData(ctx context.Context, firstEpoch uint64, pageSize uint
 				wdCreds := queueEntry.PendingDeposit.WithdrawalCredentials[:]
 				isBuilder := len(wdCreds) > 0 && wdCreds[0] == 0x03
 
-				// Postponed deposits have no churn-based estimate (they wait for their
-				// validator to become withdrawable), so EstimatedTime is left unset.
+				// EpochEstimate is the churn-based epoch for normal deposits and the
+				// validator's withdrawable epoch for postponed ones; 0 means unknown.
 				var estimatedTime time.Time
-				if !queueEntry.Postponed {
+				if queueEntry.EpochEstimate > 0 {
 					estimatedTime = chainState.EpochToTime(queueEntry.EpochEstimate)
 				}
 

--- a/handlers/queued_deposits.go
+++ b/handlers/queued_deposits.go
@@ -215,13 +215,21 @@ func buildQueuedDepositsPageData(ctx context.Context, pageIdx uint64, pageSize u
 		wdCreds := queueEntry.PendingDeposit.WithdrawalCredentials[:]
 		isBuilder := len(wdCreds) > 0 && wdCreds[0] == 0x03
 
+		// Postponed deposits have no churn-based estimate (they wait for their validator
+		// to become withdrawable), so EstimatedTime is left at its zero value.
+		var estimatedTime time.Time
+		if !queueEntry.Postponed {
+			estimatedTime = chainState.EpochToTime(queueEntry.EpochEstimate)
+		}
+
 		depositData := &models.QueuedDepositsPageDataDeposit{
 			QueuePosition:         queueEntry.QueuePos,
-			EstimatedTime:         chainState.EpochToTime(queueEntry.EpochEstimate),
+			EstimatedTime:         estimatedTime,
 			PublicKey:             queueEntry.PendingDeposit.Pubkey[:],
 			Amount:                uint64(queueEntry.PendingDeposit.Amount),
 			Withdrawalcredentials: wdCreds,
 			IsBuilder:             isBuilder,
+			Postponed:             queueEntry.Postponed,
 		}
 
 		// Get validator status if exists
@@ -284,7 +292,6 @@ func buildQueuedDepositsPageData(ctx context.Context, pageIdx uint64, pageSize u
 			if tx, txFound := txDetailsMap[depositData.Index]; txFound {
 				depositData.HasTransaction = true
 				depositData.TransactionHash = tx.TxHash
-				depositData.Withdrawalcredentials = tx.WithdrawalCredentials
 				depositData.TransactionDetails = &models.QueuedDepositsPageDataDepositTxDetails{
 					BlockNumber: tx.BlockNumber,
 					BlockHash:   fmt.Sprintf("%#x", tx.BlockRoot),

--- a/handlers/queued_deposits.go
+++ b/handlers/queued_deposits.go
@@ -215,10 +215,10 @@ func buildQueuedDepositsPageData(ctx context.Context, pageIdx uint64, pageSize u
 		wdCreds := queueEntry.PendingDeposit.WithdrawalCredentials[:]
 		isBuilder := len(wdCreds) > 0 && wdCreds[0] == 0x03
 
-		// Postponed deposits have no churn-based estimate (they wait for their validator
-		// to become withdrawable), so EstimatedTime is left at its zero value.
+		// EpochEstimate is the churn-based epoch for normal deposits and the validator's
+		// withdrawable epoch for postponed ones; 0 means unknown.
 		var estimatedTime time.Time
-		if !queueEntry.Postponed {
+		if queueEntry.EpochEstimate > 0 {
 			estimatedTime = chainState.EpochToTime(queueEntry.EpochEstimate)
 		}
 

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -961,8 +961,13 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 	if specs.ElectraForkEpoch != nil && uint64(epoch) >= *specs.ElectraForkEpoch {
 		var requests *electra.ExecutionRequests
 		if blockData.Block.Version >= spec.DataVersionGloas {
+			// In Gloas the execution requests carried by a payload are processed in the next
+			// block (as parent_execution_requests), so they are displayed there — consistent
+			// with the deposits table and the slot/epoch deposit counts. The withdrawal sweep
+			// remains part of this block's own payload.
+			requests = body.ParentExecutionRequests
+			pageData.RequestsFromParentPayload = true
 			if blockData.Payload != nil {
-				requests = blockData.Payload.Message.ExecutionRequests
 				executionWithdrawals = blockData.Payload.Message.Payload.Withdrawals
 			}
 		} else {

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -718,20 +718,23 @@ func (dbw *dbWriter) persistBlockDepositRequests(tx *sqlx.Tx, block *Block, orph
 func (dbw *dbWriter) buildDbDepositRequests(block *Block, orphaned bool, overrideForkId *ForkKey) []*dbtypes.Deposit {
 	chainState := dbw.indexer.consensusPool.GetChainState()
 
+	blockBody := block.GetBlock(dbw.indexer.ctx)
+	if blockBody == nil || blockBody.Message == nil || blockBody.Message.Body == nil {
+		return nil
+	}
+	body := blockBody.Message.Body
+
 	var requests *electra.ExecutionRequests
 
 	if chainState.IsEip7732Enabled(chainState.EpochOfSlot(block.Slot)) {
-		payload := block.GetExecutionPayload(dbw.indexer.ctx)
-		if payload != nil {
-			requests = payload.Message.ExecutionRequests
-		}
+		// In Gloas/EIP-7732 the parent's payload requests are processed in this block at
+		// this block's slot, so SlotNumber matches the beacon state's PendingDeposit.slot
+		// that the deposit queue resolver aligns against. The first Gloas block carries an
+		// empty parent_execution_requests, so the last pre-Gloas requests are not counted
+		// twice.
+		requests = body.ParentExecutionRequests
 	} else {
-		blockBody := block.GetBlock(dbw.indexer.ctx)
-		if blockBody == nil || blockBody.Message == nil || blockBody.Message.Body == nil {
-			return nil
-		}
-
-		requests = blockBody.Message.Body.ExecutionRequests
+		requests = body.ExecutionRequests
 	}
 
 	if requests == nil {

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -315,7 +315,6 @@ func (dbw *dbWriter) buildDbBlock(block *Block, epochStats *EpochStats, override
 			executionExtraData = blockPayload.Message.Payload.ExtraData
 			executionTransactions = blockPayload.Message.Payload.Transactions
 			executionWithdrawals = blockPayload.Message.Payload.Withdrawals
-			depositRequests = blockPayload.Message.ExecutionRequests.Deposits
 			payloadStatus = dbtypes.PayloadStatusCanonical
 		} else {
 			payloadStatus = dbtypes.PayloadStatusMissing
@@ -331,9 +330,13 @@ func (dbw *dbWriter) buildDbBlock(block *Block, epochStats *EpochStats, override
 			executionWithdrawals = ep.Withdrawals
 			executionBlockParentHash = ep.ParentHash[:]
 		}
-		if body.ExecutionRequests != nil {
-			depositRequests = body.ExecutionRequests.Deposits
-		}
+	}
+
+	// DepositCount reflects the deposits this block processes; in Gloas these are the
+	// parent's payload requests (parent_execution_requests), matching how the deposits
+	// table attributes them, rather than the block's own payload.
+	if processedRequests, _ := dbw.getProcessedExecutionRequests(block); processedRequests != nil {
+		depositRequests = processedRequests.Deposits
 	}
 
 	// Get builder index from block, default to -1 (self-built/MaxUint64)
@@ -559,16 +562,18 @@ func (dbw *dbWriter) buildDbEpoch(epoch phase0.Epoch, blocks []*Block, epochStat
 					dbEpoch.PayloadCount++
 					executionTransactions = blockPayload.Message.Payload.Transactions
 					executionWithdrawals = blockPayload.Message.Payload.Withdrawals
-					depositRequests = blockPayload.Message.ExecutionRequests.Deposits
 				}
 			} else {
 				if body.ExecutionPayload != nil {
 					executionTransactions = body.ExecutionPayload.Transactions
 					executionWithdrawals = body.ExecutionPayload.Withdrawals
 				}
-				if body.ExecutionRequests != nil {
-					depositRequests = body.ExecutionRequests.Deposits
-				}
+			}
+
+			// Count the deposits each block processes; in Gloas these come from the
+			// parent's payload (parent_execution_requests), matching the deposits table.
+			if processedRequests, _ := dbw.getProcessedExecutionRequests(block); processedRequests != nil {
+				depositRequests = processedRequests.Deposits
 			}
 
 			dbEpoch.AttestationCount += uint64(len(attestations))
@@ -715,28 +720,44 @@ func (dbw *dbWriter) persistBlockDepositRequests(tx *sqlx.Tx, block *Block, orph
 	return nil
 }
 
-func (dbw *dbWriter) buildDbDepositRequests(block *Block, orphaned bool, overrideForkId *ForkKey) []*dbtypes.Deposit {
+// getProcessedExecutionRequests returns the execution requests this block processes,
+// together with the EL block number they were included in.
+//
+// In Gloas/EIP-7732 a block processes its parent's payload requests
+// (parent_execution_requests) at this block's slot, so the requests are attributed to this
+// block's slot (matching the beacon state's PendingDeposit.slot). They were included in the
+// parent payload, which is the direct EL parent of this block's payload, so its block
+// number is this block's payload number minus one. Reading the requests from the block body
+// keeps them available even when the payload envelope is missing. The first Gloas block
+// carries an empty parent_execution_requests, so the last pre-Gloas requests are not counted
+// twice. In earlier forks the requests live in the block body and were included in the
+// block's own payload.
+func (dbw *dbWriter) getProcessedExecutionRequests(block *Block) (*electra.ExecutionRequests, uint64) {
 	chainState := dbw.indexer.consensusPool.GetChainState()
 
 	blockBody := block.GetBlock(dbw.indexer.ctx)
 	if blockBody == nil || blockBody.Message == nil || blockBody.Message.Body == nil {
-		return nil
+		return nil, 0
 	}
 	body := blockBody.Message.Body
 
-	var requests *electra.ExecutionRequests
-
 	if chainState.IsEip7732Enabled(chainState.EpochOfSlot(block.Slot)) {
-		// In Gloas/EIP-7732 the parent's payload requests are processed in this block at
-		// this block's slot, so SlotNumber matches the beacon state's PendingDeposit.slot
-		// that the deposit queue resolver aligns against. The first Gloas block carries an
-		// empty parent_execution_requests, so the last pre-Gloas requests are not counted
-		// twice.
-		requests = body.ParentExecutionRequests
-	} else {
-		requests = body.ExecutionRequests
+		var blockNumber uint64
+		if payload := block.GetExecutionPayload(dbw.indexer.ctx); payload != nil && payload.Message.Payload.BlockNumber > 0 {
+			blockNumber = payload.Message.Payload.BlockNumber - 1
+		}
+		return body.ParentExecutionRequests, blockNumber
 	}
 
+	var blockNumber uint64
+	if body.ExecutionPayload != nil {
+		blockNumber = body.ExecutionPayload.BlockNumber
+	}
+	return body.ExecutionRequests, blockNumber
+}
+
+func (dbw *dbWriter) buildDbDepositRequests(block *Block, orphaned bool, overrideForkId *ForkKey) []*dbtypes.Deposit {
+	requests, _ := dbw.getProcessedExecutionRequests(block)
 	if requests == nil {
 		return []*dbtypes.Deposit{}
 	}
@@ -1102,29 +1123,7 @@ func (dbw *dbWriter) persistBlockConsolidationRequests(tx *sqlx.Tx, block *Block
 }
 
 func (dbw *dbWriter) buildDbConsolidationRequests(block *Block, orphaned bool, overrideForkId *ForkKey, sim *stateSimulator) []*dbtypes.ConsolidationRequest {
-	chainState := dbw.indexer.consensusPool.GetChainState()
-
-	var requests *electra.ExecutionRequests
-	var blockNumber uint64
-
-	if chainState.IsEip7732Enabled(chainState.EpochOfSlot(block.Slot)) {
-		payload := block.GetExecutionPayload(dbw.indexer.ctx)
-		if payload != nil {
-			requests = payload.Message.ExecutionRequests
-			blockNumber = payload.Message.Payload.BlockNumber
-		}
-	} else {
-		blockBody := block.GetBlock(dbw.indexer.ctx)
-		if blockBody == nil || blockBody.Message == nil || blockBody.Message.Body == nil {
-			return nil
-		}
-
-		requests = blockBody.Message.Body.ExecutionRequests
-		if blockBody.Message.Body.ExecutionPayload != nil {
-			blockNumber = blockBody.Message.Body.ExecutionPayload.BlockNumber
-		}
-	}
-
+	requests, blockNumber := dbw.getProcessedExecutionRequests(block)
 	if requests == nil {
 		return []*dbtypes.ConsolidationRequest{}
 	}
@@ -1198,29 +1197,7 @@ func (dbw *dbWriter) persistBlockWithdrawalRequests(tx *sqlx.Tx, block *Block, o
 }
 
 func (dbw *dbWriter) buildDbWithdrawalRequests(block *Block, orphaned bool, overrideForkId *ForkKey, sim *stateSimulator) []*dbtypes.WithdrawalRequest {
-	chainState := dbw.indexer.consensusPool.GetChainState()
-
-	var requests *electra.ExecutionRequests
-	var blockNumber uint64
-
-	if chainState.IsEip7732Enabled(chainState.EpochOfSlot(block.Slot)) {
-		payload := block.GetExecutionPayload(dbw.indexer.ctx)
-		if payload != nil {
-			requests = payload.Message.ExecutionRequests
-			blockNumber = payload.Message.Payload.BlockNumber
-		}
-	} else {
-		blockBody := block.GetBlock(dbw.indexer.ctx)
-		if blockBody == nil || blockBody.Message == nil || blockBody.Message.Body == nil {
-			return nil
-		}
-
-		requests = blockBody.Message.Body.ExecutionRequests
-		if blockBody.Message.Body.ExecutionPayload != nil {
-			blockNumber = blockBody.Message.Body.ExecutionPayload.BlockNumber
-		}
-	}
-
+	requests, blockNumber := dbw.getProcessedExecutionRequests(block)
 	if requests == nil {
 		return []*dbtypes.WithdrawalRequest{}
 	}

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -332,9 +332,9 @@ func (dbw *dbWriter) buildDbBlock(block *Block, epochStats *EpochStats, override
 		}
 	}
 
-	// DepositCount reflects the deposits this block processes; in Gloas these are the
-	// parent's payload requests (parent_execution_requests), matching how the deposits
-	// table attributes them, rather than the block's own payload.
+	// DepositCount counts the deposits this block processes; in Gloas these come from the
+	// parent payload (parent_execution_requests), consistent with the deposits table and
+	// the slot detail page, which attribute requests to the block that processes them.
 	if processedRequests, _ := dbw.getProcessedExecutionRequests(block); processedRequests != nil {
 		depositRequests = processedRequests.Deposits
 	}
@@ -570,8 +570,8 @@ func (dbw *dbWriter) buildDbEpoch(epoch phase0.Epoch, blocks []*Block, epochStat
 				}
 			}
 
-			// Count the deposits each block processes; in Gloas these come from the
-			// parent's payload (parent_execution_requests), matching the deposits table.
+			// Count the deposits each block processes; in Gloas these come from the parent
+			// payload (parent_execution_requests), consistent with the deposits table.
 			if processedRequests, _ := dbw.getProcessedExecutionRequests(block); processedRequests != nil {
 				depositRequests = processedRequests.Deposits
 			}

--- a/services/chainservice_deposits.go
+++ b/services/chainservice_deposits.go
@@ -3,6 +3,7 @@ package services
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math"
 	"slices"
 	"strings"
@@ -392,6 +393,11 @@ type IndexedDepositQueueEntry struct {
 	DepositIndex   *uint64
 	EpochEstimate  phase0.Epoch
 	PendingDeposit *electra.PendingDeposit
+	// Postponed marks a deposit that process_pending_deposits reorders to the back of
+	// the queue (its validator is exiting), so it no longer follows the queue's
+	// slot<->index order and is resolved by slot rather than by position. Its
+	// EpochEstimate is left unset as it does not flow through the normal churn queue.
+	Postponed bool
 }
 
 type IndexedDepositQueue struct {
@@ -421,45 +427,19 @@ func (bs *ChainService) GetIndexedDepositQueue(ctx context.Context, headBlock *b
 		return indexedQueue
 	}
 
-	// Best-effort deposit-index assignment: the queue itself (pending_deposits) always
-	// comes from the beacon state, but the EL deposit indexes are derived by anchoring
-	// the tail of the queue to the last included deposit and counting backwards. If the
-	// anchor can't be resolved (no included deposit found yet), we still return the full
-	// queue — entries are simply left without a DepositIndex instead of hiding everything.
-	//
-	// Matching is by deposit index AND pubkey: the index sequence is not contiguous in
-	// the queue. Post-Gloas builder (0x03) deposits get an EL deposit index but are
-	// onboarded as builders and never enter the queue, leaving gaps; and 0x01->0x02
-	// compounding-switch deposits are synthesized during state transition with no EL
-	// deposit at all. We skip the synthetic ones entirely and, for real ones, skip over
-	// index gaps until the pubkey at the candidate index matches the queue entry.
+	// Assign EL deposit indexes by position, flagging postponed (reordered) entries
+	// that must instead be resolved by slot.
 	lastIncludedDeposit, includedPubkeyByIndex := bs.getRecentIncludedDeposits(ctx, queueBlockRoot)
-	if lastIncludedDeposit != nil && lastIncludedDeposit.Index != nil {
-		candidate := int64(*lastIncludedDeposit.Index)
-		for idx := len(queue) - 1; idx >= 0; idx-- {
-			deposit := queue[idx]
-			if isSyntheticPendingDeposit(deposit) {
-				continue // compounding-switch/excess-balance deposit, no EL deposit index
-			}
-			if candidate < 0 {
-				break // ran out of indexes; leave earlier entries unindexed
-			}
-			// Skip indexes that belong to deposits not present in the queue (builder
-			// gaps). A known pubkey that does not match means this index is a gap.
-			for candidate >= 0 {
-				pubkey, known := includedPubkeyByIndex[uint64(candidate)]
-				if known && pubkey != deposit.Pubkey {
-					candidate--
-					continue
-				}
-				break // matches, or unknown (beyond cache) -> accept and fall back to contiguous
-			}
-			if candidate < 0 {
-				break
-			}
-			depositIndexCopy := uint64(candidate)
-			indexedQueue.Queue[idx].DepositIndex = &depositIndexCopy
-			candidate--
+	indexes, postponed := resolveQueueDepositIndexes(queue, lastIncludedDeposit, includedPubkeyByIndex)
+	for idx := range indexedQueue.Queue {
+		indexedQueue.Queue[idx].DepositIndex = indexes[idx]
+	}
+
+	// Resolve postponed entries by slot (one batched query) and flag them for rendering.
+	bs.resolvePostponedDepositIndexes(ctx, queue, indexedQueue.Queue, postponed)
+	for idx := range indexedQueue.Queue {
+		if postponed[idx] {
+			indexedQueue.Queue[idx].Postponed = true
 		}
 	}
 
@@ -530,7 +510,10 @@ func (bs *ChainService) GetIndexedDepositQueue(ctx context.Context, headBlock *b
 	for idx, queueEntry := range indexedQueue.Queue {
 		queueEntry.QueuePos = uint64(idx)
 
-		if totalActiveBalance > 0 {
+		// Postponed deposits do not flow through the churn queue (they wait for their
+		// validator to become withdrawable), so they neither consume churn budget nor
+		// receive a churn-based estimate.
+		if !queueEntry.Postponed && totalActiveBalance > 0 {
 			if currentEpochCount >= maxPendingDepositsPerEpoch {
 				queueEpoch++
 				queueBalance = activationExitChurnLimit
@@ -554,6 +537,156 @@ func (bs *ChainService) GetIndexedDepositQueue(ctx context.Context, headBlock *b
 	indexedQueue.QueueEstimation = queueEpoch
 
 	return indexedQueue
+}
+
+// resolveQueueDepositIndexes assigns an EL deposit index to each queue entry by position
+// and flags the postponed (reordered) entries. It returns, per entry, the resolved index
+// (nil where it must be resolved by slot) and whether the entry is postponed.
+//
+// pending_deposits comes verbatim from the beacon state but carries no EL deposit index.
+// Regular deposits sit in the queue in strict slot<->index order, so their indexes are
+// derived by anchoring the tail to the last included deposit and counting backwards.
+//
+// process_pending_deposits moves deposits of an exiting validator to the back of the
+// queue, breaking that order. Such postponed entries surface as a slot that dips below
+// the running maximum; they are excluded from the backward count (left nil) and resolved
+// individually by slot afterwards. Detection is purely slot-based (independent of the
+// possibly-delayed validator set) so the assigned index is always correct.
+//
+// Matching in the backward count is by deposit index AND pubkey: post-Gloas builder
+// (0x03) deposits get an EL deposit index but never enter the queue, leaving gaps; and
+// 0x01->0x02 compounding-switch deposits are synthesized with no EL deposit at all.
+// Synthetic ones are skipped entirely, and for real ones index gaps are skipped until the
+// pubkey at the candidate index matches the queue entry.
+func resolveQueueDepositIndexes(queue []*electra.PendingDeposit, anchor *dbtypes.Deposit, includedPubkeyByIndex map[uint64]phase0.BLSPubKey) (indexes []*uint64, postponed []bool) {
+	indexes = make([]*uint64, len(queue))
+	postponed = make([]bool, len(queue))
+
+	// Forward pass: flag entries whose slot dips below the running maximum.
+	prevRegularSlot := phase0.Slot(0)
+	for idx, deposit := range queue {
+		if isSyntheticPendingDeposit(deposit) {
+			continue
+		}
+		if deposit.Slot < prevRegularSlot {
+			postponed[idx] = true
+			continue
+		}
+		prevRegularSlot = deposit.Slot
+	}
+
+	// Backward pass: assign indexes to the regular (in-order) entries.
+	tailRegularIdx := -1
+	if anchor != nil && anchor.Index != nil {
+		candidate := int64(*anchor.Index)
+		for idx := len(queue) - 1; idx >= 0; idx-- {
+			deposit := queue[idx]
+			if isSyntheticPendingDeposit(deposit) || postponed[idx] {
+				continue
+			}
+			if candidate < 0 {
+				break // ran out of indexes; leave earlier entries unindexed
+			}
+			// Skip indexes that belong to deposits not present in the queue (builder
+			// gaps). A known pubkey that does not match means this index is a gap.
+			for candidate >= 0 {
+				pubkey, known := includedPubkeyByIndex[uint64(candidate)]
+				if known && pubkey != deposit.Pubkey {
+					candidate--
+					continue
+				}
+				break // matches, or unknown (beyond cache) -> accept and fall back to contiguous
+			}
+			if candidate < 0 {
+				break
+			}
+			if tailRegularIdx < 0 {
+				tailRegularIdx = idx
+			}
+			depositIndexCopy := uint64(candidate)
+			indexes[idx] = &depositIndexCopy
+			candidate--
+		}
+	}
+
+	// Anchor verification. The tail-most regular entry must align with the anchor's slot.
+	// If it doesn't (a degenerate queue whose most recent deposits are all postponed or
+	// builder deposits, so the anchor is not the real tail), the positional assignment
+	// cannot be trusted and every non-synthetic entry is resolved by slot instead. This
+	// recovers the "queue is nothing but postponed deposits" case, which has no slot dip.
+	anchorVerified := tailRegularIdx >= 0 && anchor != nil &&
+		queue[tailRegularIdx].Slot == phase0.Slot(anchor.SlotNumber)
+	if !anchorVerified {
+		for idx, deposit := range queue {
+			if isSyntheticPendingDeposit(deposit) {
+				continue
+			}
+			postponed[idx] = true
+			indexes[idx] = nil
+		}
+	}
+
+	return indexes, postponed
+}
+
+// resolvePostponedDepositIndexes fills in the EL deposit index of queue entries flagged
+// as postponed. These were reordered out of the queue's slot<->index sequence, so they
+// can't be aligned by position; instead they are looked up in a single batched query by
+// their slot (which equals the beacon state's PendingDeposit.slot) and matched on
+// (slot, pubkey, amount, withdrawal_credentials). Byte-identical deposits sharing a slot
+// are consumed in slot_index order, matching their queue order. Entries with no DB match
+// are left without an index rather than mis-assigned.
+func (bs *ChainService) resolvePostponedDepositIndexes(ctx context.Context, queue []*electra.PendingDeposit, entries []*IndexedDepositQueueEntry, postponed []bool) {
+	slotSet := make(map[uint64]struct{})
+	for idx, isPostponed := range postponed {
+		if isPostponed {
+			slotSet[uint64(queue[idx].Slot)] = struct{}{}
+		}
+	}
+	if len(slotSet) == 0 {
+		return
+	}
+
+	slots := make([]uint64, 0, len(slotSet))
+	for slot := range slotSet {
+		slots = append(slots, slot)
+	}
+
+	rows, err := db.GetDepositRequestsBySlots(ctx, slots, bs.GetCanonicalForkIds())
+	if err != nil {
+		logrus.Warnf("ChainService.resolvePostponedDepositIndexes error: %v", err)
+		return
+	}
+
+	depositKey := func(slot, amount uint64, pubkey, wdcreds []byte) string {
+		return fmt.Sprintf("%d-%x-%d-%x", slot, pubkey, amount, wdcreds)
+	}
+
+	// Rows arrive ordered by (slot_number, slot_index), so identical deposits keep their
+	// inclusion order within each key.
+	indexesByKey := make(map[string][]uint64, len(rows))
+	for _, row := range rows {
+		if row.Index == nil {
+			continue
+		}
+		key := depositKey(row.SlotNumber, row.Amount, row.PublicKey, row.WithdrawalCredentials)
+		indexesByKey[key] = append(indexesByKey[key], *row.Index)
+	}
+
+	for idx, isPostponed := range postponed {
+		if !isPostponed {
+			continue
+		}
+		deposit := queue[idx]
+		key := depositKey(uint64(deposit.Slot), uint64(deposit.Amount), deposit.Pubkey[:], deposit.WithdrawalCredentials)
+		indexes := indexesByKey[key]
+		if len(indexes) == 0 {
+			continue
+		}
+		depositIndexCopy := indexes[0]
+		indexesByKey[key] = indexes[1:]
+		entries[idx].DepositIndex = &depositIndexCopy
+	}
 }
 
 // isSyntheticPendingDeposit reports whether a pending deposit was synthesized during

--- a/services/chainservice_deposits.go
+++ b/services/chainservice_deposits.go
@@ -511,13 +511,25 @@ func (bs *ChainService) GetIndexedDepositQueue(ctx context.Context, headBlock *b
 	for idx, queueEntry := range indexedQueue.Queue {
 		queueEntry.QueuePos = uint64(idx)
 
-		switch {
-		case queueEntry.Postponed:
-			// Postponed deposits do not flow through the churn queue; they are applied once
-			// their validator becomes withdrawable, so estimate from that epoch.
-			queueEntry.EpochEstimate = bs.postponedDepositEpoch(queueEntry.PendingDeposit.Pubkey)
-
-		case totalActiveBalance > 0:
+		if queueEntry.Postponed {
+			// A postponed deposit is processed at the later of when the churn queue reaches
+			// its position (queueEpoch — postponed deposits sit at the back) and when its
+			// validator becomes withdrawable. If the queue would only reach it after the
+			// validator is already withdrawable, it is processed like a normal queued deposit
+			// and is no longer flagged postponed; otherwise the exit is the bottleneck and it
+			// keeps waiting. Postponed deposits are applied without consuming churn.
+			exitEpoch := bs.postponedDepositEpoch(queueEntry.PendingDeposit.Pubkey)
+			switch {
+			case exitEpoch == 0:
+				// validator/exit unknown: keep flagged, no estimate
+			case exitEpoch > queueEpoch:
+				queueEntry.EpochEstimate = exitEpoch
+			default:
+				queueEntry.EpochEstimate = queueEpoch
+				queueEntry.Postponed = false
+				hasChurnDeposit = true
+			}
+		} else if totalActiveBalance > 0 {
 			if currentEpochCount >= maxPendingDepositsPerEpoch {
 				queueEpoch++
 				queueBalance = activationExitChurnLimit

--- a/services/chainservice_deposits.go
+++ b/services/chainservice_deposits.go
@@ -635,7 +635,7 @@ func resolveQueueDepositIndexes(queue []*electra.PendingDeposit, anchor *dbtypes
 // their slot (which equals the beacon state's PendingDeposit.slot) and matched on
 // (slot, pubkey, amount, withdrawal_credentials). Byte-identical deposits sharing a slot
 // are consumed in slot_index order, matching their queue order. Entries with no DB match
-// are left without an index rather than mis-assigned.
+// are left without an index rather than wrongly assigned.
 func (bs *ChainService) resolvePostponedDepositIndexes(ctx context.Context, queue []*electra.PendingDeposit, entries []*IndexedDepositQueueEntry, postponed []bool) {
 	slotSet := make(map[uint64]struct{})
 	for idx, isPostponed := range postponed {

--- a/services/chainservice_deposits.go
+++ b/services/chainservice_deposits.go
@@ -506,14 +506,18 @@ func (bs *ChainService) GetIndexedDepositQueue(ctx context.Context, headBlock *b
 	queueEpoch++
 	queueBalance += activationExitChurnLimit
 	currentEpochCount := uint64(0)
+	hasChurnDeposit := false
 
 	for idx, queueEntry := range indexedQueue.Queue {
 		queueEntry.QueuePos = uint64(idx)
 
-		// Postponed deposits do not flow through the churn queue (they wait for their
-		// validator to become withdrawable), so they neither consume churn budget nor
-		// receive a churn-based estimate.
-		if !queueEntry.Postponed && totalActiveBalance > 0 {
+		switch {
+		case queueEntry.Postponed:
+			// Postponed deposits do not flow through the churn queue; they are applied once
+			// their validator becomes withdrawable, so estimate from that epoch.
+			queueEntry.EpochEstimate = bs.postponedDepositEpoch(queueEntry.PendingDeposit.Pubkey)
+
+		case totalActiveBalance > 0:
 			if currentEpochCount >= maxPendingDepositsPerEpoch {
 				queueEpoch++
 				queueBalance = activationExitChurnLimit
@@ -529,14 +533,38 @@ func (bs *ChainService) GetIndexedDepositQueue(ctx context.Context, headBlock *b
 			queueEntry.EpochEstimate = queueEpoch
 			currentEpochCount++
 			queueBalance -= queueEntry.PendingDeposit.Amount
+			hasChurnDeposit = true
 		}
 
 		indexedQueue.TotalGwei += queueEntry.PendingDeposit.Amount
 	}
 
-	indexedQueue.QueueEstimation = queueEpoch
+	// Only deposits flowing through the churn queue contribute to the overall processing
+	// estimate; an empty or all-postponed queue leaves QueueEstimation at 0 (rendered as
+	// "--").
+	if hasChurnDeposit {
+		indexedQueue.QueueEstimation = queueEpoch
+	}
 
 	return indexedQueue
+}
+
+// postponedDepositEpoch estimates when a postponed deposit will be applied: the epoch its
+// validator becomes withdrawable. Returns 0 (unknown) if the validator can't be resolved or
+// has no concrete withdrawable epoch yet.
+func (bs *ChainService) postponedDepositEpoch(pubkey phase0.BLSPubKey) phase0.Epoch {
+	validatorIdx, found := bs.beaconIndexer.GetValidatorIndexByPubkey(pubkey)
+	if !found || uint64(validatorIdx)&BuilderIndexFlag != 0 {
+		return 0
+	}
+	validator := bs.GetValidatorByIndex(validatorIdx, false)
+	if validator == nil || validator.Validator == nil {
+		return 0
+	}
+	if validator.Validator.WithdrawableEpoch >= beacon.FarFutureEpoch {
+		return 0
+	}
+	return validator.Validator.WithdrawableEpoch
 }
 
 // resolveQueueDepositIndexes assigns an EL deposit index to each queue entry by position

--- a/templates/deposits/deposits.html
+++ b/templates/deposits/deposits.html
@@ -409,7 +409,7 @@
               <td>{{ $deposit.QueuePosition }}</td>
               {{ if $deposit.Postponed }}
               <td>
-                {{ if not $deposit.EstimatedTime.IsZero }}<span data-timer="{{ $deposit.EstimatedTime.Unix }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Applied when the validator becomes withdrawable ({{ $deposit.EstimatedTime }})">{{ formatRecentTimeShort $deposit.EstimatedTime }}</span> {{ end }}<span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This deposit is for an exiting validator. It is postponed each epoch until the validator becomes withdrawable and does not move through the normal deposit queue.">postponed</span>
+                {{ if not $deposit.EstimatedTime.IsZero }}<span data-timer="{{ $deposit.EstimatedTime.Unix }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $deposit.EstimatedTime }}">{{ formatRecentTimeShort $deposit.EstimatedTime }}</span> {{ end }}<span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This deposit is for an exiting validator. It can only be processed once the validator becomes withdrawable; the estimate is that epoch, after which it still has to run through the queue to be applied.">postponed</span>
               </td>
               {{ else }}
               <td data-timer="{{ $deposit.EstimatedTime.Unix }}">

--- a/templates/deposits/deposits.html
+++ b/templates/deposits/deposits.html
@@ -403,11 +403,15 @@
           {{ range $i, $deposit := .QueuedDeposits }}
             <tr>
               <td>{{ $deposit.QueuePosition }}</td>
+              {{ if $deposit.Postponed }}
+              <td><span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This deposit is for an exiting validator. It is postponed each epoch until the validator becomes withdrawable and does not move through the normal deposit queue.">postponed</span></td>
+              {{ else }}
               <td data-timer="{{ $deposit.EstimatedTime.Unix }}">
                 <span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $deposit.EstimatedTime }}">
                   {{ formatRecentTimeShort $deposit.EstimatedTime }}
                 </span>
               </td>
+              {{ end }}
               <td>
                 {{ if $deposit.HasIndex }}
                   <span class="badge rounded-pill text-bg-primary" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This deposit was triggered via a validator deposit transaction">{{ $deposit.Index }}</span>

--- a/templates/deposits/deposits.html
+++ b/templates/deposits/deposits.html
@@ -37,7 +37,11 @@
             <div class="card">
               <div class="card-body text-center">
                 <h6 class="card-title text-muted mb-1">Queue Processing Time</h6>
+                {{ if .NewDepositProcessAfter.IsZero }}
+                <h4 class="mb-0" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="No deposits are currently flowing through the churn queue">--</h4>
+                {{ else }}
                 <h4 class="mb-0" data-timer="{{ .NewDepositProcessAfter.Unix }}"><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ .NewDepositProcessAfter }}">{{ formatRecentTimeShort .NewDepositProcessAfter }}</span></h4>
+                {{ end }}
               </div>
             </div>
           </div>
@@ -404,7 +408,9 @@
             <tr>
               <td>{{ $deposit.QueuePosition }}</td>
               {{ if $deposit.Postponed }}
-              <td><span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This deposit is for an exiting validator. It is postponed each epoch until the validator becomes withdrawable and does not move through the normal deposit queue.">postponed</span></td>
+              <td>
+                {{ if not $deposit.EstimatedTime.IsZero }}<span data-timer="{{ $deposit.EstimatedTime.Unix }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Applied when the validator becomes withdrawable ({{ $deposit.EstimatedTime }})">{{ formatRecentTimeShort $deposit.EstimatedTime }}</span> {{ end }}<span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This deposit is for an exiting validator. It is postponed each epoch until the validator becomes withdrawable and does not move through the normal deposit queue.">postponed</span>
+              </td>
               {{ else }}
               <td data-timer="{{ $deposit.EstimatedTime.Unix }}">
                 <span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $deposit.EstimatedTime }}">
@@ -493,6 +499,55 @@
   <div class="text-center">
     <a class="text-white" href="/validators/queued_deposits">View more</a>
   </div>
+  <div class="tx-details-content d-none">
+    <div>
+      <div class="d-flex">
+        <div class="tx-details-label">Tx Hash:</div>
+        <div class="flex-grow-1 tx-details-value">
+          <div class="d-flex">
+            <span class="flex-grow-1 text-truncate txdetails-txhash"></span>
+            <div><i class="fa fa-copy text-muted ml-2 p-1 txdetails-txhash-copy" role="button" data-bs-toggle="tooltip" title="Copy to clipboard"></i></div>
+          </div>
+        </div>
+      </div>
+      <div class="d-flex">
+        <div class="tx-details-label">Block:</div>
+        <div class="flex-grow-1 tx-details-value">
+          <div class="d-flex">
+            <span class="flex-grow-1 text-truncate txdetails-block"></span>
+            <div><i class="fa fa-copy text-muted ml-2 p-1 txdetails-block-copy" role="button" data-bs-toggle="tooltip" title="Copy to clipboard"></i></div>
+          </div>
+        </div>
+      </div>
+      <div class="d-flex">
+        <div class="tx-details-label">Block Time:</div>
+        <div class="flex-grow-1 tx-details-value">
+          <div class="d-flex">
+            <span class="flex-grow-1 text-truncate txdetails-time"></span>
+            <div><i class="fa fa-copy text-muted ml-2 p-1 txdetails-time-copy" role="button" data-bs-toggle="tooltip" title="Copy to clipboard"></i></div>
+          </div>
+        </div>
+      </div>
+      <div class="d-flex">
+        <div class="tx-details-label">TX Origin:</div>
+        <div class="flex-grow-1 tx-details-value">
+          <div class="d-flex">
+            <span class="flex-grow-1 text-truncate txdetails-txorigin"></span>
+            <div><i class="fa fa-copy text-muted ml-2 p-1 txdetails-txorigin-copy" role="button" data-bs-toggle="tooltip" title="Copy to clipboard"></i></div>
+          </div>
+        </div>
+      </div>
+      <div class="d-flex">
+        <div class="tx-details-label">TX Target:</div>
+        <div class="flex-grow-1 tx-details-value">
+          <div class="d-flex">
+            <span class="flex-grow-1 text-truncate txdetails-txtarget"></span>
+            <div><i class="fa fa-copy text-muted ml-2 p-1 txdetails-txtarget-copy" role="button" data-bs-toggle="tooltip" title="Copy to clipboard"></i></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 {{ end }}
 
@@ -502,6 +557,60 @@
     const tabEl = document.querySelectorAll('a[data-lazy-tab]')
     Array.from(tabEl).forEach(el => {
       el.addEventListener('click', onTabSelected);
+    });
+
+    // Transaction details popover for queued deposits. Delegated so it also works for
+    // lazily-loaded tab content.
+    var lastTxPopover = null;
+    $(document).on('click', '.tx-details-btn', function() {
+      var txdetails = $(this).data('txdetails');
+      var container = $(".tx-details-content");
+      container.find(".txdetails-txhash").text(txdetails.tx_hash);
+      container.find(".txdetails-txhash-copy").attr("data-clipboard-text", txdetails.tx_hash);
+      container.find(".txdetails-block").text(txdetails.block);
+      container.find(".txdetails-block-copy").attr("data-clipboard-text", txdetails.block);
+
+      var blockTimeRelative = window.explorer.renderRecentTime(txdetails.block_time);
+      var blockTimeAbsolute = new Date(txdetails.block_time * 1000).toISOString();
+      container.find(".txdetails-time").text(blockTimeRelative);
+      container.find(".txdetails-time-copy").attr("data-clipboard-text", blockTimeAbsolute);
+      container.find(".txdetails-txorigin").text(txdetails.tx_origin);
+      container.find(".txdetails-txorigin-copy").attr("data-clipboard-text", txdetails.tx_origin);
+      container.find(".txdetails-txtarget").text(txdetails.tx_target);
+      container.find(".txdetails-txtarget-copy").attr("data-clipboard-text", txdetails.tx_target);
+
+      var txDetailsContent = container.html();
+
+      var popover = bootstrap.Popover.getOrCreateInstance(this, {
+        html: true,
+        title: 'Transaction Details',
+        content: 'loading...',
+        trigger: 'manual',
+        customClass: 'tx-details-popover'
+      });
+
+      if (lastTxPopover === popover) {
+        return;
+      }
+      if (lastTxPopover) {
+        lastTxPopover.hide();
+      }
+      lastTxPopover = popover;
+
+      popover.show();
+
+      $(".tx-details-popover .popover-body").html(txDetailsContent);
+      window.explorer.initControls();
+    });
+
+    $(window).on('click', function(evt) {
+      if ($(evt.target).closest('.tx-details-btn').length > 0 || $(evt.target).closest('.tx-details-popover').length > 0) {
+        return;
+      }
+      if (lastTxPopover) {
+        lastTxPopover.hide();
+        lastTxPopover = null;
+      }
     });
 
     function onTabSelected(event) {
@@ -533,6 +642,18 @@
 }
 .tab-content {
   padding-top: 1rem;
+}
+.tx-details-label {
+  min-width: 90px;
+}
+.tx-details-value {
+  max-width: calc(100% - 90px);
+}
+.tx-details-popover {
+  max-width: 470px;
+}
+.tx-details-popover .popover-body {
+  padding: 8px;
 }
 </style>
 {{ end }}

--- a/templates/queued_deposits/queued_deposits.html
+++ b/templates/queued_deposits/queued_deposits.html
@@ -122,7 +122,11 @@
                 {{ range $i, $deposit := .Deposits }}
                   <tr>
                     <td>{{ $deposit.QueuePosition }}</td>
+                    {{ if $deposit.Postponed }}
+                    <td><span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This deposit is for an exiting validator. It is postponed each epoch until the validator becomes withdrawable and does not move through the normal deposit queue.">postponed</span></td>
+                    {{ else }}
                     <td data-timer="{{ $deposit.EstimatedTime.Unix }}"><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $deposit.EstimatedTime }}">{{ formatRecentTimeShort $deposit.EstimatedTime }}</span></td>
+                    {{ end }}
                     <td>
                       {{ if $deposit.HasIndex }}
                         <span class="badge rounded-pill text-bg-primary" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This deposit was triggered via a validator deposit transaction">{{ $deposit.Index }}</span>

--- a/templates/queued_deposits/queued_deposits.html
+++ b/templates/queued_deposits/queued_deposits.html
@@ -123,7 +123,9 @@
                   <tr>
                     <td>{{ $deposit.QueuePosition }}</td>
                     {{ if $deposit.Postponed }}
-                    <td><span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This deposit is for an exiting validator. It is postponed each epoch until the validator becomes withdrawable and does not move through the normal deposit queue.">postponed</span></td>
+                    <td>
+                      {{ if not $deposit.EstimatedTime.IsZero }}<span data-timer="{{ $deposit.EstimatedTime.Unix }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Applied when the validator becomes withdrawable ({{ $deposit.EstimatedTime }})">{{ formatRecentTimeShort $deposit.EstimatedTime }}</span> {{ end }}<span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This deposit is for an exiting validator. It is postponed each epoch until the validator becomes withdrawable and does not move through the normal deposit queue.">postponed</span>
+                    </td>
                     {{ else }}
                     <td data-timer="{{ $deposit.EstimatedTime.Unix }}"><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $deposit.EstimatedTime }}">{{ formatRecentTimeShort $deposit.EstimatedTime }}</span></td>
                     {{ end }}

--- a/templates/queued_deposits/queued_deposits.html
+++ b/templates/queued_deposits/queued_deposits.html
@@ -124,7 +124,7 @@
                     <td>{{ $deposit.QueuePosition }}</td>
                     {{ if $deposit.Postponed }}
                     <td>
-                      {{ if not $deposit.EstimatedTime.IsZero }}<span data-timer="{{ $deposit.EstimatedTime.Unix }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Applied when the validator becomes withdrawable ({{ $deposit.EstimatedTime }})">{{ formatRecentTimeShort $deposit.EstimatedTime }}</span> {{ end }}<span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This deposit is for an exiting validator. It is postponed each epoch until the validator becomes withdrawable and does not move through the normal deposit queue.">postponed</span>
+                      {{ if not $deposit.EstimatedTime.IsZero }}<span data-timer="{{ $deposit.EstimatedTime.Unix }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $deposit.EstimatedTime }}">{{ formatRecentTimeShort $deposit.EstimatedTime }}</span> {{ end }}<span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="This deposit is for an exiting validator. It can only be processed once the validator becomes withdrawable; the estimate is that epoch, after which it still has to run through the queue to be applied.">postponed</span>
                     </td>
                     {{ else }}
                     <td data-timer="{{ $deposit.EstimatedTime.Unix }}"><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $deposit.EstimatedTime }}">{{ formatRecentTimeShort $deposit.EstimatedTime }}</span></td>

--- a/templates/slot/slot.html
+++ b/templates/slot/slot.html
@@ -253,6 +253,7 @@
               <div style="margin-bottom: -.25rem;" class="card-body px-0 py-1">
                 <div class="row p-1 mx-0">
                   <h3 class="h5 col-md-12 text-center"><b>Showing {{ .Block.DepositRequestsCount }} Deposit Requests</b></h3>
+                  {{ if .Block.RequestsFromParentPayload }}<p class="col-md-12 text-center text-muted mb-0"><small>These requests were included in the parent block's payload and are processed in this block.</small></p>{{ end }}
                 </div>
               </div>
             </div>
@@ -265,6 +266,7 @@
               <div style="margin-bottom: -.25rem;" class="card-body px-0 py-1">
                 <div class="row p-1 mx-0">
                   <h3 class="h5 col-md-12 text-center"><b>Showing {{ .Block.WithdrawalRequestsCount }} Withdrawal Requests</b></h3>
+                  {{ if .Block.RequestsFromParentPayload }}<p class="col-md-12 text-center text-muted mb-0"><small>These requests were included in the parent block's payload and are processed in this block.</small></p>{{ end }}
                 </div>
               </div>
             </div>
@@ -277,6 +279,7 @@
               <div style="margin-bottom: -.25rem;" class="card-body px-0 py-1">
                 <div class="row p-1 mx-0">
                   <h3 class="h5 col-md-12 text-center"><b>Showing {{ .Block.ConsolidationRequestsCount }} Consolidation Requests </b></h3>
+                  {{ if .Block.RequestsFromParentPayload }}<p class="col-md-12 text-center text-muted mb-0"><small>These requests were included in the parent block's payload and are processed in this block (EIP-7732).</small></p>{{ end }}
                 </div>
               </div>
             </div>

--- a/types/models/deposits.go
+++ b/types/models/deposits.go
@@ -104,6 +104,7 @@ type DepositsPageDataQueuedDeposit struct {
 	ProjectedIndex        bool                                    `json:"projected_index"`
 	ValidatorName         string                                  `json:"validator_name"`
 	IsBuilder             bool                                    `json:"is_builder"`
+	Postponed             bool                                    `json:"postponed"`
 }
 
 type DepositsPageDataQueuedDepositTxDetails struct {

--- a/types/models/queued_deposits.go
+++ b/types/models/queued_deposits.go
@@ -56,6 +56,7 @@ type QueuedDepositsPageDataDeposit struct {
 	ProjectedIndex        bool                                    `json:"projected_index"`
 	ValidatorName         string                                  `json:"validator_name"`
 	IsBuilder             bool                                    `json:"is_builder"`
+	Postponed             bool                                    `json:"postponed"`
 }
 
 type QueuedDepositsPageDataDepositTxDetails struct {

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -80,6 +80,7 @@ type SlotPageBlockData struct {
 	DepositRequestsCount       uint64                  `json:"deposit_receipts_count"`
 	WithdrawalRequestsCount    uint64                  `json:"withdrawal_requests_count"`
 	ConsolidationRequestsCount uint64                  `json:"consolidation_requests_count"`
+	RequestsFromParentPayload  bool                    `json:"requests_from_parent_payload"`
 	BidsCount                  uint64                  `json:"bids_count"`
 	PtcVotesCount              uint64                  `json:"ptc_votes_count"`
 


### PR DESCRIPTION
Fixes deposit-queue and execution-request handling for Gloas (EIP-7732), where execution requests are carried in a payload but processed in the **next** block (as `parent_execution_requests`). Previously requests were indexed against the payload's own block, causing wrong slots, wrong tx/withdrawal-credential links on the deposit queue, and mismatched deposit counts.

## Execution-request slot attribution (deposits, withdrawal & consolidation requests)

A shared `getProcessedExecutionRequests(block)` helper now sources execution requests from the block that **processes** them:
- Gloas: `body.ParentExecutionRequests`, attributed to this block's slot (= the beacon state's `PendingDeposit.slot`). EL block number is the parent payload's (`own_payload_number - 1`).
- Pre-Gloas: unchanged (`body.ExecutionRequests`).
- Reading from the block body (not the payload envelope) keeps requests available even when the payload is missing, and the empty `parent_execution_requests` of the first Gloas block avoids double-counting at the fork boundary.

This is applied consistently across the deposit/withdrawal/consolidation request indexers, the slot & epoch deposit-count aggregations, and the slot detail page (which now renders `parent_execution_requests` with a note that they were included in the parent payload). EL transaction matching is unaffected — deposits match by intrinsic `deposit_index`, withdrawal/consolidation requests by `block_number` (parent payload EL block).

## Deposit queue index resolution (`GetIndexedDepositQueue`)

The queue's EL indexes were reconstructed by positional backward-counting, which breaks for deposits that `process_pending_deposits` postpones (reorders to the back of the queue for exiting validators) — they were matched to unrelated recent deposits, showing wrong tx hashes / withdrawal credentials.

- Resolution is now slot-based (independent of the possibly-stale validator set): forward slot-dip detection flags postponed entries, regulars keep the backward-count, and anchor-slot verification recovers the all-postponed case.
- Postponed entries are resolved by a single bounded query (`db.GetDepositRequestsBySlots`) matched on `(slot, pubkey, amount, withdrawal_credentials)`.
- Handlers no longer overwrite withdrawal credentials with the matched tx's — the beacon-state value is authoritative.

## Postponed-deposit UX

- New `Postponed` flag plumbed to the deposit overview, queued-deposits page, and API.
- Processing-time estimate for postponed deposits = `max(churn-queue position, validator withdrawable epoch)`. If the queue would reach the deposit only after the validator is withdrawable it's treated as a normal queued deposit (flag cleared); otherwise it shows the exit-based estimate with a "postponed" badge explaining it still runs through the queue once withdrawable.
- "Queue Processing Time" shows `--` for an empty or all-postponed queue instead of a bogus estimate.
- Deposit overview queue tab: renders the postponed badge and wires up the transaction-details popover (previously missing on that tab).

<img width="1522" height="915" alt="image" src="https://github.com/user-attachments/assets/091de411-4def-400a-aebd-ea58a1f013a6" />

## Misc

- `dora-utils migrate`: added `--exclude-tables` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)